### PR TITLE
Output field path in strict errors

### DIFF
--- a/internal/golang/encoding/json/decode_test.go
+++ b/internal/golang/encoding/json/decode_test.go
@@ -899,7 +899,7 @@ var unmarshalTests = []unmarshalTest{
 			"Q": 18
 		}`,
 		ptr:                   new(Top),
-		err:                   fmt.Errorf("json: unknown field \"extra\""),
+		err:                   fmt.Errorf("json: unknown field \"e.extra\""),
 		disallowUnknownFields: true,
 	},
 	// issue 26444

--- a/json_test.go
+++ b/json_test.go
@@ -103,8 +103,8 @@ func TestUnmarshal(t *testing.T) {
 			name:             "duplicate map field",
 			in:               `{"c":{"a":"1","a":"2","b":"1","b":"2"}}`,
 			to:               func() interface{} { return &Obj{} },
-			expect:           &Obj{C: map[string]string{"a": "2", "b": "2"}},         // last duplicates win
-			expectStrictErrs: []string{`duplicate field "a"`, `duplicate field "b"`}, // multiple strict errors are returned
+			expect:           &Obj{C: map[string]string{"a": "2", "b": "2"}},             // last duplicates win
+			expectStrictErrs: []string{`duplicate field "c.a"`, `duplicate field "c.b"`}, // multiple strict errors are returned
 		},
 		{
 			name:             "unknown fields",


### PR DESCRIPTION
Fixes https://github.com/kubernetes-sigs/json/issues/4

When decoding strictly, includes path context in errors for unknown and duplicate fields.

This is needed for parity with the client-side validation this is replacing.

```
benchmark                                       old allocs     new allocs     delta
BenchmarkUnmarshal/typed_stdlib-12              161            161            +0.00%
BenchmarkUnmarshal/typed_unmarshal-12           161            161            +0.00%
BenchmarkUnmarshal/typed_strict-12              167            171            +2.40%
BenchmarkUnmarshal/typed_strict-custom-12       168            172            +2.38%
BenchmarkUnmarshal/untyped_stdlib-12            517            517            +0.00%
BenchmarkUnmarshal/untyped_unmarshal-12         513            521            +1.56%
BenchmarkUnmarshal/untyped_strict-12            523            535            +2.29%
BenchmarkUnmarshal/untyped_strict-custom-12     524            536            +2.29%

benchmark                                       old bytes     new bytes     delta
BenchmarkUnmarshal/typed_stdlib-12              13240         13240         +0.00%
BenchmarkUnmarshal/typed_unmarshal-12           13272         13304         +0.24%
BenchmarkUnmarshal/typed_strict-12              13784         14168         +2.79%
BenchmarkUnmarshal/typed_strict-custom-12       13816         14200         +2.78%
BenchmarkUnmarshal/untyped_stdlib-12            28213         28203         -0.04%
BenchmarkUnmarshal/untyped_unmarshal-12         28190         28252         +0.22%
BenchmarkUnmarshal/untyped_strict-12            28411         28849         +1.54%
BenchmarkUnmarshal/untyped_strict-custom-12     28448         28880         +1.52%
```

running benchmarks with bigger/deeper objects (e.g. medium-size serialized pods):

```
benchmark                                      old allocs     new allocs     delta
BenchmarkUnmarshalTyped/std-unmarshal-12       161            161            +0.00%
BenchmarkUnmarshalTyped/std-decode-12          171            171            +0.00%
BenchmarkUnmarshalTyped/utiljson-12            161            161            +0.00%
BenchmarkUnmarshalTyped/kjson-12               161            164            +1.86%
BenchmarkUnmarshalTyped/kjson-strict-12        168            176            +4.76%
BenchmarkUnmarshalUntyped/std-unmarshal-12     521            521            +0.00%
BenchmarkUnmarshalUntyped/std-decode-12        531            531            +0.00%
BenchmarkUnmarshalUntyped/utiljson-12          536            536            +0.00%
BenchmarkUnmarshalUntyped/kjson-12             519            524            +0.96%
BenchmarkUnmarshalUntyped/kjson-strict-12      526            537            +2.09%

benchmark                                      old bytes     new bytes     delta
BenchmarkUnmarshalTyped/std-unmarshal-12       12672         12672         +0.00%
BenchmarkUnmarshalTyped/std-decode-12          27472         27472         +0.00%
BenchmarkUnmarshalTyped/utiljson-12            12672         12672         +0.00%
BenchmarkUnmarshalTyped/kjson-12               12704         12760         +0.44%
BenchmarkUnmarshalTyped/kjson-strict-12        13112         13664         +4.21%
BenchmarkUnmarshalUntyped/std-unmarshal-12     27033         27032         -0.00%
BenchmarkUnmarshalUntyped/std-decode-12        41847         41850         +0.01%
BenchmarkUnmarshalUntyped/utiljson-12          41945         41944         -0.00%
BenchmarkUnmarshalUntyped/kjson-12             27064         27143         +0.29%
BenchmarkUnmarshalUntyped/kjson-strict-12      27303         28375         +3.93%
```