### PR TITLE
feat: compatible with go1.16

### DIFF
--- a/internal/golang/encoding/json/encode.go
+++ b/internal/golang/encoding/json/encode.go
@@ -1246,13 +1246,13 @@ func typeFields(t reflect.Type) structFields {
 					if t.Kind() == reflect.Ptr {
 						t = t.Elem()
 					}
-					if !sf.IsExported() && t.Kind() != reflect.Struct {
+					if sf.PkgPath != "" && t.Kind() != reflect.Struct {
 						// Ignore embedded fields of unexported non-struct types.
 						continue
 					}
 					// Do not ignore embedded fields of unexported struct types
 					// since they may have exported fields.
-				} else if !sf.IsExported() {
+				} else if sf.PkgPath != "" {
 					// Ignore unexported non-embedded fields.
 					continue
 				}


### PR DESCRIPTION
`StructField.IsExported` added in go1.17. https://pkg.go.dev/reflect#StructField.IsExported 