### PR TITLE
Check latest go version in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,7 @@ jobs:
       with:
         go-version: "1.x"
         stable: true
+        check-latest: true
 
     - name: Test
       run: |


### PR DESCRIPTION
CI is stuck thinking go1.17 is the latest version (xref https://github.com/kubernetes-sigs/json/runs/5727177657?check_suite_focus=true)