### PR TITLE
sync go1.19 changes from encoding/json

### DIFF
--- a/internal/golang/encoding/json/decode.go
+++ b/internal/golang/encoding/json/decode.go
@@ -75,6 +75,8 @@ import (
 // either be any string type, an integer, implement json.Unmarshaler, or
 // implement encoding.TextUnmarshaler.
 //
+// If the JSON-encoded data contain a syntax error, Unmarshal returns a SyntaxError.
+//
 // If a JSON value is not appropriate for a given target type,
 // or if a JSON number overflows the target type, Unmarshal
 // skips that field and completes the unmarshaling as best it can.
@@ -85,14 +87,13 @@ import (
 //
 // The JSON null value unmarshals into an interface, map, pointer, or slice
 // by setting that Go value to nil. Because null is often used in JSON to mean
-// ``not present,'' unmarshaling a JSON null into any other Go type has no effect
+// “not present,” unmarshaling a JSON null into any other Go type has no effect
 // on the value and produces no error.
 //
 // When unmarshaling quoted strings, invalid UTF-8 or
 // invalid UTF-16 surrogate pairs are not treated as an error.
 // Instead, they are replaced by the Unicode replacement
 // character U+FFFD.
-//
 func Unmarshal(data []byte, v any, opts ...UnmarshalOpt) error {
 	// Check for well-formedness.
 	// Avoids filling out half a data structure

--- a/internal/golang/encoding/json/encode.go
+++ b/internal/golang/encoding/json/encode.go
@@ -77,31 +77,31 @@ import (
 //
 // Examples of struct field tags and their meanings:
 //
-//   // Field appears in JSON as key "myName".
-//   Field int `json:"myName"`
+//	// Field appears in JSON as key "myName".
+//	Field int `json:"myName"`
 //
-//   // Field appears in JSON as key "myName" and
-//   // the field is omitted from the object if its value is empty,
-//   // as defined above.
-//   Field int `json:"myName,omitempty"`
+//	// Field appears in JSON as key "myName" and
+//	// the field is omitted from the object if its value is empty,
+//	// as defined above.
+//	Field int `json:"myName,omitempty"`
 //
-//   // Field appears in JSON as key "Field" (the default), but
-//   // the field is skipped if empty.
-//   // Note the leading comma.
-//   Field int `json:",omitempty"`
+//	// Field appears in JSON as key "Field" (the default), but
+//	// the field is skipped if empty.
+//	// Note the leading comma.
+//	Field int `json:",omitempty"`
 //
-//   // Field is ignored by this package.
-//   Field int `json:"-"`
+//	// Field is ignored by this package.
+//	Field int `json:"-"`
 //
-//   // Field appears in JSON as key "-".
-//   Field int `json:"-,"`
+//	// Field appears in JSON as key "-".
+//	Field int `json:"-,"`
 //
 // The "string" option signals that a field is stored as JSON inside a
 // JSON-encoded string. It applies only to fields of string, floating point,
 // integer, or boolean types. This extra level of encoding is sometimes used
 // when communicating with JavaScript programs:
 //
-//    Int64String int64 `json:",string"`
+//	Int64String int64 `json:",string"`
 //
 // The key name will be used if it's a non-empty string consisting of
 // only Unicode letters, digits, and ASCII punctuation except quotation
@@ -154,7 +154,6 @@ import (
 // JSON cannot represent cyclic data structures and Marshal does not
 // handle them. Passing cyclic structures to Marshal will result in
 // an error.
-//
 func Marshal(v any) ([]byte, error) {
 	e := newEncodeState()
 
@@ -784,7 +783,7 @@ func (me mapEncoder) encode(e *encodeState, v reflect.Value, opts encOpts) {
 	if e.ptrLevel++; e.ptrLevel > startDetectingCyclesAfter {
 		// We're a large number of nested ptrEncoder.encode calls deep;
 		// start checking if we've run into a pointer cycle.
-		ptr := v.Pointer()
+		ptr := v.UnsafePointer()
 		if _, ok := e.ptrSeen[ptr]; ok {
 			e.error(&UnsupportedValueError{v, fmt.Sprintf("encountered a cycle via %s", v.Type())})
 		}
@@ -877,9 +876,9 @@ func (se sliceEncoder) encode(e *encodeState, v reflect.Value, opts encOpts) {
 		// Here we use a struct to memorize the pointer to the first element of the slice
 		// and its length.
 		ptr := struct {
-			ptr uintptr
+			ptr interface{} // always an unsafe.Pointer, but avoids a dependency on package unsafe
 			len int
-		}{v.Pointer(), v.Len()}
+		}{v.UnsafePointer(), v.Len()}
 		if _, ok := e.ptrSeen[ptr]; ok {
 			e.error(&UnsupportedValueError{v, fmt.Sprintf("encountered a cycle via %s", v.Type())})
 		}

--- a/internal/golang/encoding/json/fold.go
+++ b/internal/golang/encoding/json/fold.go
@@ -24,8 +24,9 @@ const (
 // 4) simpleLetterEqualFold, no specials, no non-letters.
 //
 // The letters S and K are special because they map to 3 runes, not just 2:
-//  * S maps to s and to U+017F 'ſ' Latin small letter long s
-//  * k maps to K and to U+212A 'K' Kelvin sign
+//   - S maps to s and to U+017F 'ſ' Latin small letter long s
+//   - k maps to K and to U+212A 'K' Kelvin sign
+//
 // See https://play.golang.org/p/tTxjOc0OGo
 //
 // The returned function is specialized for matching against s and

--- a/internal/golang/encoding/json/scanner.go
+++ b/internal/golang/encoding/json/scanner.go
@@ -27,6 +27,7 @@ func Valid(data []byte) bool {
 
 // checkValid verifies that data is valid JSON-encoded data.
 // scan is passed in for use by checkValid to avoid an allocation.
+// checkValid returns nil or a SyntaxError.
 func checkValid(data []byte, scan *scanner) error {
 	scan.reset()
 	for _, c := range data {
@@ -42,6 +43,7 @@ func checkValid(data []byte, scan *scanner) error {
 }
 
 // A SyntaxError is a description of a JSON syntax error.
+// Unmarshal will return a SyntaxError if the JSON can't be parsed.
 type SyntaxError struct {
 	msg    string // description of error
 	Offset int64  // error occurred after reading Offset bytes

--- a/internal/golang/encoding/json/stream.go
+++ b/internal/golang/encoding/json/stream.go
@@ -289,7 +289,6 @@ var _ Unmarshaler = (*RawMessage)(nil)
 //	Number, for JSON numbers
 //	string, for JSON string literals
 //	nil, for JSON null
-//
 type Token any
 */
 

--- a/json.go
+++ b/json.go
@@ -34,13 +34,13 @@ type Decoder interface {
 }
 
 // NewDecoderCaseSensitivePreserveInts returns a decoder that matches the behavior of encoding/json#NewDecoder, with the following changes:
-// - When unmarshaling into a struct, JSON keys must case-sensitively match `json` tag names (for tagged struct fields)
-//   or struct field names (for untagged struct fields), or they are treated as unknown fields and discarded.
-// - When unmarshaling a number into an interface value, it is unmarshaled as an int64 if
-//   the JSON data does not contain a "." character and parses as an integer successfully and
-//   does not overflow int64. Otherwise, the number is unmarshaled as a float64.
-// - If a syntax error is returned, it will not be of type encoding/json#SyntaxError,
-//   but will be recognizeable by this package's IsSyntaxError() function.
+//   - When unmarshaling into a struct, JSON keys must case-sensitively match `json` tag names (for tagged struct fields)
+//     or struct field names (for untagged struct fields), or they are treated as unknown fields and discarded.
+//   - When unmarshaling a number into an interface value, it is unmarshaled as an int64 if
+//     the JSON data does not contain a "." character and parses as an integer successfully and
+//     does not overflow int64. Otherwise, the number is unmarshaled as a float64.
+//   - If a syntax error is returned, it will not be of type encoding/json#SyntaxError,
+//     but will be recognizeable by this package's IsSyntaxError() function.
 func NewDecoderCaseSensitivePreserveInts(r io.Reader) Decoder {
 	d := internaljson.NewDecoder(r)
 	d.CaseSensitive()
@@ -51,13 +51,13 @@ func NewDecoderCaseSensitivePreserveInts(r io.Reader) Decoder {
 // UnmarshalCaseSensitivePreserveInts parses the JSON-encoded data and stores the result in the value pointed to by v.
 //
 // UnmarshalCaseSensitivePreserveInts matches the behavior of encoding/json#Unmarshal, with the following changes:
-// - When unmarshaling into a struct, JSON keys must case-sensitively match `json` tag names (for tagged struct fields)
-//   or struct field names (for untagged struct fields), or they are treated as unknown fields and discarded.
-// - When unmarshaling a number into an interface value, it is unmarshaled as an int64 if
-//   the JSON data does not contain a "." character and parses as an integer successfully and
-//   does not overflow int64. Otherwise, the number is unmarshaled as a float64.
-// - If a syntax error is returned, it will not be of type encoding/json#SyntaxError,
-//   but will be recognizeable by this package's IsSyntaxError() function.
+//   - When unmarshaling into a struct, JSON keys must case-sensitively match `json` tag names (for tagged struct fields)
+//     or struct field names (for untagged struct fields), or they are treated as unknown fields and discarded.
+//   - When unmarshaling a number into an interface value, it is unmarshaled as an int64 if
+//     the JSON data does not contain a "." character and parses as an integer successfully and
+//     does not overflow int64. Otherwise, the number is unmarshaled as a float64.
+//   - If a syntax error is returned, it will not be of type encoding/json#SyntaxError,
+//     but will be recognizeable by this package's IsSyntaxError() function.
 func UnmarshalCaseSensitivePreserveInts(data []byte, v interface{}) error {
 	return internaljson.Unmarshal(
 		data,


### PR DESCRIPTION
```
git log --format=oneline upstream/release-branch.go1.18..upstream/release-branch.go1.19 -- src/encoding/json/

46ab7a5c4f80d912f25b6b3e1044282a2a79df8b encoding/json: mention SyntaxError in Unmarshal doc comment
19309779ac5e2f5a2fd3cbb34421dafb2855ac21 all: gofmt main repo
81431c7aa7c5d782e72dec342442ea7664ef1783 all: replace `` and '' with “ (U+201C) and ” (U+201D) in doc comments
690ac4071fa3e07113bf371c9e74394ab54d6749 all: remove trailing blank doc comment lines
5a03cbd12a2fcaf85482f1f4d9570c064510da9b encoding/json: use reflect.Value.UnsafePointer over Pointer
```