### PR TITLE
Sync with go1.23

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ vet:
 	go vet sigs.k8s.io/json
 
 	@echo "checking for external dependencies"
-	@deps=$$(go mod graph); \
+	@deps=$$(go list -f '{{ if not (or .Standard .Module.Main) }}{{.ImportPath}}{{ end }}' -deps sigs.k8s.io/json/... || true); \
 	if [ -n "$${deps}" ]; then \
 		echo "only stdlib dependencies allowed, found:"; \
 		echo "$${deps}"; \

--- a/OWNERS
+++ b/OWNERS
@@ -2,5 +2,5 @@
 
 approvers:
   - deads2k
-  - lavalamp
+  - jpbetz
   - liggitt

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module sigs.k8s.io/json
 
-go 1.18
+go 1.21

--- a/internal/golang/encoding/json/bench_test.go
+++ b/internal/golang/encoding/json/bench_test.go
@@ -14,9 +14,11 @@ import (
 	"bytes"
 	"compress/gzip"
 	"fmt"
+	"internal/testenv"
 	"io"
 	"os"
 	"reflect"
+	"regexp"
 	"runtime"
 	"strings"
 	"sync"
@@ -91,7 +93,37 @@ func BenchmarkCodeEncoder(b *testing.B) {
 		enc := NewEncoder(io.Discard)
 		for pb.Next() {
 			if err := enc.Encode(&codeStruct); err != nil {
-				b.Fatal("Encode:", err)
+				b.Fatalf("Encode error: %v", err)
+			}
+		}
+	})
+	b.SetBytes(int64(len(codeJSON)))
+}
+
+func BenchmarkCodeEncoderError(b *testing.B) {
+	b.ReportAllocs()
+	if codeJSON == nil {
+		b.StopTimer()
+		codeInit()
+		b.StartTimer()
+	}
+
+	// Trigger an error in Marshal with cyclic data.
+	type Dummy struct {
+		Name string
+		Next *Dummy
+	}
+	dummy := Dummy{Name: "Dummy"}
+	dummy.Next = &dummy
+
+	b.RunParallel(func(pb *testing.PB) {
+		enc := NewEncoder(io.Discard)
+		for pb.Next() {
+			if err := enc.Encode(&codeStruct); err != nil {
+				b.Fatalf("Encode error: %v", err)
+			}
+			if _, err := Marshal(dummy); err == nil {
+				b.Fatal("Marshal error: got nil, want non-nil")
 			}
 		}
 	})
@@ -108,7 +140,36 @@ func BenchmarkCodeMarshal(b *testing.B) {
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {
 			if _, err := Marshal(&codeStruct); err != nil {
-				b.Fatal("Marshal:", err)
+				b.Fatalf("Marshal error: %v", err)
+			}
+		}
+	})
+	b.SetBytes(int64(len(codeJSON)))
+}
+
+func BenchmarkCodeMarshalError(b *testing.B) {
+	b.ReportAllocs()
+	if codeJSON == nil {
+		b.StopTimer()
+		codeInit()
+		b.StartTimer()
+	}
+
+	// Trigger an error in Marshal with cyclic data.
+	type Dummy struct {
+		Name string
+		Next *Dummy
+	}
+	dummy := Dummy{Name: "Dummy"}
+	dummy.Next = &dummy
+
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			if _, err := Marshal(&codeStruct); err != nil {
+				b.Fatalf("Marshal error: %v", err)
+			}
+			if _, err := Marshal(dummy); err == nil {
+				b.Fatal("Marshal error: got nil, want non-nil")
 			}
 		}
 	})
@@ -127,7 +188,37 @@ func benchMarshalBytes(n int) func(*testing.B) {
 	return func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
 			if _, err := Marshal(v); err != nil {
-				b.Fatal("Marshal:", err)
+				b.Fatalf("Marshal error: %v", err)
+			}
+		}
+	}
+}
+
+func benchMarshalBytesError(n int) func(*testing.B) {
+	sample := []byte("hello world")
+	// Use a struct pointer, to avoid an allocation when passing it as an
+	// interface parameter to Marshal.
+	v := &struct {
+		Bytes []byte
+	}{
+		bytes.Repeat(sample, (n/len(sample))+1)[:n],
+	}
+
+	// Trigger an error in Marshal with cyclic data.
+	type Dummy struct {
+		Name string
+		Next *Dummy
+	}
+	dummy := Dummy{Name: "Dummy"}
+	dummy.Next = &dummy
+
+	return func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			if _, err := Marshal(v); err != nil {
+				b.Fatalf("Marshal error: %v", err)
+			}
+			if _, err := Marshal(dummy); err == nil {
+				b.Fatal("Marshal error: got nil, want non-nil")
 			}
 		}
 	}
@@ -142,6 +233,33 @@ func BenchmarkMarshalBytes(b *testing.B) {
 	b.Run("256", benchMarshalBytes(256))
 	// 4096 is large enough that we want to avoid allocating for it.
 	b.Run("4096", benchMarshalBytes(4096))
+}
+
+func BenchmarkMarshalBytesError(b *testing.B) {
+	b.ReportAllocs()
+	// 32 fits within encodeState.scratch.
+	b.Run("32", benchMarshalBytesError(32))
+	// 256 doesn't fit in encodeState.scratch, but is small enough to
+	// allocate and avoid the slower base64.NewEncoder.
+	b.Run("256", benchMarshalBytesError(256))
+	// 4096 is large enough that we want to avoid allocating for it.
+	b.Run("4096", benchMarshalBytesError(4096))
+}
+
+func BenchmarkMarshalMap(b *testing.B) {
+	b.ReportAllocs()
+	m := map[string]int{
+		"key3": 3,
+		"key2": 2,
+		"key1": 1,
+	}
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			if _, err := Marshal(m); err != nil {
+				b.Fatal("Marshal:", err)
+			}
+		}
+	})
 }
 
 func BenchmarkCodeDecoder(b *testing.B) {
@@ -162,7 +280,7 @@ func BenchmarkCodeDecoder(b *testing.B) {
 			buf.WriteByte('\n')
 			buf.WriteByte('\n')
 			if err := dec.Decode(&r); err != nil {
-				b.Fatal("Decode:", err)
+				b.Fatalf("Decode error: %v", err)
 			}
 		}
 	})
@@ -179,7 +297,7 @@ func BenchmarkUnicodeDecoder(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		if err := dec.Decode(&out); err != nil {
-			b.Fatal("Decode:", err)
+			b.Fatalf("Decode error: %v", err)
 		}
 		r.Seek(0, 0)
 	}
@@ -193,7 +311,7 @@ func BenchmarkDecoderStream(b *testing.B) {
 	buf.WriteString(`"` + strings.Repeat("x", 1000000) + `"` + "\n\n\n")
 	var x any
 	if err := dec.Decode(&x); err != nil {
-		b.Fatal("Decode:", err)
+		b.Fatalf("Decode error: %v", err)
 	}
 	ones := strings.Repeat(" 1\n", 300000) + "\n\n\n"
 	b.StartTimer()
@@ -202,8 +320,11 @@ func BenchmarkDecoderStream(b *testing.B) {
 			buf.WriteString(ones)
 		}
 		x = nil
-		if err := dec.Decode(&x); err != nil || x != 1.0 {
-			b.Fatalf("Decode: %v after %d", err, i)
+		switch err := dec.Decode(&x); {
+		case err != nil:
+			b.Fatalf("Decode error: %v", err)
+		case x != 1.0:
+			b.Fatalf("Decode: got %v want 1.0", i)
 		}
 	}
 }
@@ -219,7 +340,7 @@ func BenchmarkCodeUnmarshal(b *testing.B) {
 		for pb.Next() {
 			var r codeResponse
 			if err := Unmarshal(codeJSON, &r); err != nil {
-				b.Fatal("Unmarshal:", err)
+				b.Fatalf("Unmarshal error: %v", err)
 			}
 		}
 	})
@@ -237,7 +358,7 @@ func BenchmarkCodeUnmarshalReuse(b *testing.B) {
 		var r codeResponse
 		for pb.Next() {
 			if err := Unmarshal(codeJSON, &r); err != nil {
-				b.Fatal("Unmarshal:", err)
+				b.Fatalf("Unmarshal error: %v", err)
 			}
 		}
 	})
@@ -251,7 +372,7 @@ func BenchmarkUnmarshalString(b *testing.B) {
 		var s string
 		for pb.Next() {
 			if err := Unmarshal(data, &s); err != nil {
-				b.Fatal("Unmarshal:", err)
+				b.Fatalf("Unmarshal error: %v", err)
 			}
 		}
 	})
@@ -264,7 +385,7 @@ func BenchmarkUnmarshalFloat64(b *testing.B) {
 		var f float64
 		for pb.Next() {
 			if err := Unmarshal(data, &f); err != nil {
-				b.Fatal("Unmarshal:", err)
+				b.Fatalf("Unmarshal error: %v", err)
 			}
 		}
 	})
@@ -277,7 +398,20 @@ func BenchmarkUnmarshalInt64(b *testing.B) {
 		var x int64
 		for pb.Next() {
 			if err := Unmarshal(data, &x); err != nil {
-				b.Fatal("Unmarshal:", err)
+				b.Fatalf("Unmarshal error: %v", err)
+			}
+		}
+	})
+}
+
+func BenchmarkUnmarshalMap(b *testing.B) {
+	b.ReportAllocs()
+	data := []byte(`{"key1":"value1","key2":"value2","key3":"value3"}`)
+	b.RunParallel(func(pb *testing.PB) {
+		x := make(map[string]string, 3)
+		for pb.Next() {
+			if err := Unmarshal(data, &x); err != nil {
+				b.Fatalf("Unmarshal error: %v", err)
 			}
 		}
 	})
@@ -290,7 +424,7 @@ func BenchmarkIssue10335(b *testing.B) {
 		var s struct{}
 		for pb.Next() {
 			if err := Unmarshal(j, &s); err != nil {
-				b.Fatal(err)
+				b.Fatalf("Unmarshal error: %v", err)
 			}
 		}
 	})
@@ -306,7 +440,7 @@ func BenchmarkIssue34127(b *testing.B) {
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {
 			if _, err := Marshal(&j); err != nil {
-				b.Fatal(err)
+				b.Fatalf("Marshal error: %v", err)
 			}
 		}
 	})
@@ -319,7 +453,7 @@ func BenchmarkUnmapped(b *testing.B) {
 		var s struct{}
 		for pb.Next() {
 			if err := Unmarshal(j, &s); err != nil {
-				b.Fatal(err)
+				b.Fatalf("Unmarshal error: %v", err)
 			}
 		}
 	})
@@ -328,12 +462,14 @@ func BenchmarkUnmapped(b *testing.B) {
 func BenchmarkTypeFieldsCache(b *testing.B) {
 	b.ReportAllocs()
 	var maxTypes int = 1e6
-	maxTypes = 1e3 // restrict cache sizes on builders
+	if testenv.Builder() != "" {
+		maxTypes = 1e3 // restrict cache sizes on builders
+	}
 
 	// Dynamically generate many new types.
 	types := make([]reflect.Type, maxTypes)
 	fs := []reflect.StructField{{
-		Type:  reflect.TypeOf(""),
+		Type:  reflect.TypeFor[string](),
 		Index: []int{0},
 	}}
 	for i := range types {
@@ -400,8 +536,49 @@ func BenchmarkEncodeMarshaler(b *testing.B) {
 
 		for pb.Next() {
 			if err := enc.Encode(&m); err != nil {
-				b.Fatal("Encode:", err)
+				b.Fatalf("Encode error: %v", err)
 			}
 		}
 	})
+}
+
+func BenchmarkEncoderEncode(b *testing.B) {
+	b.ReportAllocs()
+	type T struct {
+		X, Y string
+	}
+	v := &T{"foo", "bar"}
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			if err := NewEncoder(io.Discard).Encode(v); err != nil {
+				b.Fatalf("Encode error: %v", err)
+			}
+		}
+	})
+}
+
+func BenchmarkNumberIsValid(b *testing.B) {
+	s := "-61657.61667E+61673"
+	for i := 0; i < b.N; i++ {
+		isValidNumber(s)
+	}
+}
+
+func BenchmarkNumberIsValidRegexp(b *testing.B) {
+	var jsonNumberRegexp = regexp.MustCompile(`^-?(?:0|[1-9]\d*)(?:\.\d+)?(?:[eE][+-]?\d+)?$`)
+	s := "-61657.61667E+61673"
+	for i := 0; i < b.N; i++ {
+		jsonNumberRegexp.MatchString(s)
+	}
+}
+
+func BenchmarkUnmarshalNumber(b *testing.B) {
+	b.ReportAllocs()
+	data := []byte(`"-61657.61667E+61673"`)
+	var number Number
+	for i := 0; i < b.N; i++ {
+		if err := Unmarshal(data, &number); err != nil {
+			b.Fatal("Unmarshal:", err)
+		}
+	}
 }

--- a/internal/golang/encoding/json/bench_test.go
+++ b/internal/golang/encoding/json/bench_test.go
@@ -14,7 +14,6 @@ import (
 	"bytes"
 	"compress/gzip"
 	"fmt"
-	"internal/testenv"
 	"io"
 	"os"
 	"reflect"
@@ -462,9 +461,7 @@ func BenchmarkUnmapped(b *testing.B) {
 func BenchmarkTypeFieldsCache(b *testing.B) {
 	b.ReportAllocs()
 	var maxTypes int = 1e6
-	if testenv.Builder() != "" {
-		maxTypes = 1e3 // restrict cache sizes on builders
-	}
+	maxTypes = 1e3 // restrict cache sizes on builders
 
 	// Dynamically generate many new types.
 	types := make([]reflect.Type, maxTypes)

--- a/internal/golang/encoding/json/decode.go
+++ b/internal/golang/encoding/json/decode.go
@@ -17,14 +17,15 @@ import (
 	"unicode"
 	"unicode/utf16"
 	"unicode/utf8"
+	_ "unsafe" // for linkname
 )
 
 // Unmarshal parses the JSON-encoded data and stores the result
 // in the value pointed to by v. If v is nil or not a pointer,
-// Unmarshal returns an InvalidUnmarshalError.
+// Unmarshal returns an [InvalidUnmarshalError].
 //
 // Unmarshal uses the inverse of the encodings that
-// Marshal uses, allocating maps, slices, and pointers as necessary,
+// [Marshal] uses, allocating maps, slices, and pointers as necessary,
 // with the following additional rules:
 //
 // To unmarshal JSON into a pointer, Unmarshal first handles the case of
@@ -33,28 +34,28 @@ import (
 // the value pointed at by the pointer. If the pointer is nil, Unmarshal
 // allocates a new value for it to point to.
 //
-// To unmarshal JSON into a value implementing the Unmarshaler interface,
-// Unmarshal calls that value's UnmarshalJSON method, including
+// To unmarshal JSON into a value implementing [Unmarshaler],
+// Unmarshal calls that value's [Unmarshaler.UnmarshalJSON] method, including
 // when the input is a JSON null.
-// Otherwise, if the value implements encoding.TextUnmarshaler
-// and the input is a JSON quoted string, Unmarshal calls that value's
-// UnmarshalText method with the unquoted form of the string.
+// Otherwise, if the value implements [encoding.TextUnmarshaler]
+// and the input is a JSON quoted string, Unmarshal calls
+// [encoding.TextUnmarshaler.UnmarshalText] with the unquoted form of the string.
 //
 // To unmarshal JSON into a struct, Unmarshal matches incoming object
-// keys to the keys used by Marshal (either the struct field name or its tag),
+// keys to the keys used by [Marshal] (either the struct field name or its tag),
 // preferring an exact match but also accepting a case-insensitive match. By
 // default, object keys which don't have a corresponding struct field are
-// ignored (see Decoder.DisallowUnknownFields for an alternative).
+// ignored (see [Decoder.DisallowUnknownFields] for an alternative).
 //
 // To unmarshal JSON into an interface value,
 // Unmarshal stores one of these in the interface value:
 //
-//	bool, for JSON booleans
-//	float64, for JSON numbers
-//	string, for JSON strings
-//	[]interface{}, for JSON arrays
-//	map[string]interface{}, for JSON objects
-//	nil for JSON null
+//   - bool, for JSON booleans
+//   - float64, for JSON numbers
+//   - string, for JSON strings
+//   - []interface{}, for JSON arrays
+//   - map[string]interface{}, for JSON objects
+//   - nil for JSON null
 //
 // To unmarshal a JSON array into a slice, Unmarshal resets the slice length
 // to zero and then appends each element to the slice.
@@ -72,16 +73,15 @@ import (
 // use. If the map is nil, Unmarshal allocates a new map. Otherwise Unmarshal
 // reuses the existing map, keeping existing entries. Unmarshal then stores
 // key-value pairs from the JSON object into the map. The map's key type must
-// either be any string type, an integer, implement json.Unmarshaler, or
-// implement encoding.TextUnmarshaler.
+// either be any string type, an integer, or implement [encoding.TextUnmarshaler].
 //
-// If the JSON-encoded data contain a syntax error, Unmarshal returns a SyntaxError.
+// If the JSON-encoded data contain a syntax error, Unmarshal returns a [SyntaxError].
 //
 // If a JSON value is not appropriate for a given target type,
 // or if a JSON number overflows the target type, Unmarshal
 // skips that field and completes the unmarshaling as best it can.
 // If no more serious errors are encountered, Unmarshal returns
-// an UnmarshalTypeError describing the earliest such error. In any
+// an [UnmarshalTypeError] describing the earliest such error. In any
 // case, it's not guaranteed that all the remaining fields following
 // the problematic one will be unmarshaled into the target object.
 //
@@ -94,16 +94,11 @@ import (
 // invalid UTF-16 surrogate pairs are not treated as an error.
 // Instead, they are replaced by the Unicode replacement
 // character U+FFFD.
-func Unmarshal(data []byte, v any, opts ...UnmarshalOpt) error {
+func Unmarshal(data []byte, v any) error {
 	// Check for well-formedness.
 	// Avoids filling out half a data structure
 	// before discovering a JSON syntax error.
 	var d decodeState
-
-	for _, opt := range opts {
-		opt(&d)
-	}
-
 	err := checkValid(data, &d.scan)
 	if err != nil {
 		return err
@@ -119,13 +114,12 @@ func Unmarshal(data []byte, v any, opts ...UnmarshalOpt) error {
 // a JSON value. UnmarshalJSON must copy the JSON data
 // if it wishes to retain the data after returning.
 //
-// By convention, to approximate the behavior of Unmarshal itself,
+// By convention, to approximate the behavior of [Unmarshal] itself,
 // Unmarshalers implement UnmarshalJSON([]byte("null")) as a no-op.
 type Unmarshaler interface {
 	UnmarshalJSON([]byte) error
 }
 
-/*
 // An UnmarshalTypeError describes a JSON value that was
 // not appropriate for a value of a specific Go type.
 type UnmarshalTypeError struct {
@@ -157,8 +151,8 @@ func (e *UnmarshalFieldError) Error() string {
 	return "json: cannot unmarshal object key " + strconv.Quote(e.Key) + " into unexported field " + e.Field.Name + " of type " + e.Type.String()
 }
 
-// An InvalidUnmarshalError describes an invalid argument passed to Unmarshal.
-// (The argument to Unmarshal must be a non-nil pointer.)
+// An InvalidUnmarshalError describes an invalid argument passed to [Unmarshal].
+// (The argument to [Unmarshal] must be a non-nil pointer.)
 type InvalidUnmarshalError struct {
 	Type reflect.Type
 }
@@ -173,7 +167,6 @@ func (e *InvalidUnmarshalError) Error() string {
 	}
 	return "json: Unmarshal(nil " + e.Type.String() + ")"
 }
-*/
 
 func (d *decodeState) unmarshal(v any) error {
 	rv := reflect.ValueOf(v)
@@ -189,16 +182,9 @@ func (d *decodeState) unmarshal(v any) error {
 	if err != nil {
 		return d.addErrorContext(err)
 	}
-	if d.savedError != nil {
-		return d.savedError
-	}
-	if len(d.savedStrictErrors) > 0 {
-		return &UnmarshalStrictError{Errors: d.savedStrictErrors}
-	}
-	return nil
+	return d.savedError
 }
 
-/*
 // A Number represents a JSON number literal.
 type Number string
 
@@ -214,7 +200,6 @@ func (n Number) Float64() (float64, error) {
 func (n Number) Int64() (int64, error) {
 	return strconv.ParseInt(string(n), 10, 64)
 }
-*/
 
 // An errorContext provides context for type errors during decoding.
 type errorContext struct {
@@ -232,16 +217,6 @@ type decodeState struct {
 	savedError            error
 	useNumber             bool
 	disallowUnknownFields bool
-
-	savedStrictErrors []error
-	seenStrictErrors  map[strictError]struct{}
-	strictFieldStack  []string
-
-	caseSensitive bool
-
-	preserveInts bool
-
-	disallowDuplicateFields bool
 }
 
 // readIndex returns the position of the last byte read.
@@ -263,8 +238,6 @@ func (d *decodeState) init(data []byte) *decodeState {
 		// Reuse the allocated space for the FieldStack slice.
 		d.errorContext.FieldStack = d.errorContext.FieldStack[:0]
 	}
-	// Reuse the allocated space for the strict FieldStack slice.
-	d.strictFieldStack = d.strictFieldStack[:0]
 	return d
 }
 
@@ -559,12 +532,6 @@ func (d *decodeState) array(v reflect.Value) error {
 		break
 	}
 
-	origStrictFieldStackLen := len(d.strictFieldStack)
-	defer func() {
-		// Reset to original length and reuse the allocated space for the strict FieldStack slice.
-		d.strictFieldStack = d.strictFieldStack[:origStrictFieldStackLen]
-	}()
-
 	i := 0
 	for {
 		// Look ahead for ] - can only happen on first iteration.
@@ -573,24 +540,16 @@ func (d *decodeState) array(v reflect.Value) error {
 			break
 		}
 
-		// Get element of array, growing if necessary.
+		// Expand slice length, growing the slice if necessary.
 		if v.Kind() == reflect.Slice {
-			// Grow slice if necessary
 			if i >= v.Cap() {
-				newcap := v.Cap() + v.Cap()/2
-				if newcap < 4 {
-					newcap = 4
-				}
-				newv := reflect.MakeSlice(v.Type(), v.Len(), newcap)
-				reflect.Copy(newv, v)
-				v.Set(newv)
+				v.Grow(1)
 			}
 			if i >= v.Len() {
 				v.SetLen(i + 1)
 			}
 		}
 
-		d.appendStrictFieldStackIndex(i)
 		if i < v.Len() {
 			// Decode into element.
 			if err := d.value(v.Index(i)); err != nil {
@@ -602,8 +561,6 @@ func (d *decodeState) array(v reflect.Value) error {
 				return err
 			}
 		}
-		// Reset to original length and reuse the allocated space for the strict FieldStack slice.
-		d.strictFieldStack = d.strictFieldStack[:origStrictFieldStackLen]
 		i++
 
 		// Next token must be , or ].
@@ -620,13 +577,11 @@ func (d *decodeState) array(v reflect.Value) error {
 
 	if i < v.Len() {
 		if v.Kind() == reflect.Array {
-			// Array. Zero the rest.
-			z := reflect.Zero(v.Type().Elem())
 			for ; i < v.Len(); i++ {
-				v.Index(i).Set(z)
+				v.Index(i).SetZero() // zero remainder of array
 			}
 		} else {
-			v.SetLen(i)
+			v.SetLen(i) // truncate the slice
 		}
 	}
 	if i == 0 && v.Kind() == reflect.Slice {
@@ -636,7 +591,7 @@ func (d *decodeState) array(v reflect.Value) error {
 }
 
 var nullLiteral = []byte("null")
-var textUnmarshalerType = reflect.TypeOf((*encoding.TextUnmarshaler)(nil)).Elem()
+var textUnmarshalerType = reflect.TypeFor[encoding.TextUnmarshaler]()
 
 // object consumes an object from d.data[d.off-1:], decoding into v.
 // The first byte ('{') of the object has been read already.
@@ -664,7 +619,6 @@ func (d *decodeState) object(v reflect.Value) error {
 	}
 
 	var fields structFields
-	var checkDuplicateField func(fieldNameIndex int, fieldName string)
 
 	// Check type of target:
 	//   struct or
@@ -688,51 +642,8 @@ func (d *decodeState) object(v reflect.Value) error {
 		if v.IsNil() {
 			v.Set(reflect.MakeMap(t))
 		}
-
-		if d.disallowDuplicateFields {
-			var seenKeys map[string]struct{}
-			checkDuplicateField = func(fieldNameIndex int, fieldName string) {
-				if seenKeys == nil {
-					seenKeys = map[string]struct{}{}
-				}
-				if _, seen := seenKeys[fieldName]; seen {
-					d.saveStrictError(d.newFieldError(duplicateStrictErrType, fieldName))
-				} else {
-					seenKeys[fieldName] = struct{}{}
-				}
-			}
-		}
-
 	case reflect.Struct:
 		fields = cachedTypeFields(t)
-
-		if d.disallowDuplicateFields {
-			if len(fields.list) <= 64 {
-				// bitset by field index for structs with <= 64 fields
-				var seenKeys uint64
-				checkDuplicateField = func(fieldNameIndex int, fieldName string) {
-					if seenKeys&(1<<fieldNameIndex) != 0 {
-						d.saveStrictError(d.newFieldError(duplicateStrictErrType, fieldName))
-					} else {
-						seenKeys = seenKeys | (1 << fieldNameIndex)
-					}
-				}
-			} else {
-				// list of seen field indices for structs with greater than 64 fields
-				var seenIndexes []bool
-				checkDuplicateField = func(fieldNameIndex int, fieldName string) {
-					if seenIndexes == nil {
-						seenIndexes = make([]bool, len(fields.list))
-					}
-					if seenIndexes[fieldNameIndex] {
-						d.saveStrictError(d.newFieldError(duplicateStrictErrType, fieldName))
-					} else {
-						seenIndexes[fieldNameIndex] = true
-					}
-				}
-			}
-		}
-
 		// ok
 	default:
 		d.saveError(&UnmarshalTypeError{Value: "object", Type: t, Offset: int64(d.off)})
@@ -745,7 +656,6 @@ func (d *decodeState) object(v reflect.Value) error {
 	if d.errorContext != nil {
 		origErrorContext = *d.errorContext
 	}
-	origStrictFieldStackLen := len(d.strictFieldStack)
 
 	for {
 		// Read opening " of string key or closing }.
@@ -776,34 +686,13 @@ func (d *decodeState) object(v reflect.Value) error {
 			if !mapElem.IsValid() {
 				mapElem = reflect.New(elemType).Elem()
 			} else {
-				mapElem.Set(reflect.Zero(elemType))
+				mapElem.SetZero()
 			}
 			subv = mapElem
-			if checkDuplicateField != nil {
-				checkDuplicateField(0, string(key))
-			}
-			d.appendStrictFieldStackKey(string(key))
 		} else {
-			var f *field
-			if i, ok := fields.nameIndex[string(key)]; ok {
-				// Found an exact name match.
-				f = &fields.list[i]
-				if checkDuplicateField != nil {
-					checkDuplicateField(i, f.name)
-				}
-			} else if !d.caseSensitive {
-				// Fall back to the expensive case-insensitive
-				// linear search.
-				for i := range fields.list {
-					ff := &fields.list[i]
-					if ff.equalFold(ff.nameBytes, key) {
-						f = ff
-						if checkDuplicateField != nil {
-							checkDuplicateField(i, f.name)
-						}
-						break
-					}
-				}
+			f := fields.byExactName[string(key)]
+			if f == nil {
+				f = fields.byFoldedName[string(foldName(key))]
 			}
 			if f != nil {
 				subv = v
@@ -835,9 +724,8 @@ func (d *decodeState) object(v reflect.Value) error {
 				}
 				d.errorContext.FieldStack = append(d.errorContext.FieldStack, f.name)
 				d.errorContext.Struct = t
-				d.appendStrictFieldStackKey(f.name)
 			} else if d.disallowUnknownFields {
-				d.saveStrictError(d.newFieldError(unknownStrictErrType, string(key)))
+				d.saveError(fmt.Errorf("json: unknown field %q", key))
 			}
 		}
 
@@ -874,33 +762,35 @@ func (d *decodeState) object(v reflect.Value) error {
 		if v.Kind() == reflect.Map {
 			kt := t.Key()
 			var kv reflect.Value
-			switch {
-			case reflect.PointerTo(kt).Implements(textUnmarshalerType):
+			if reflect.PointerTo(kt).Implements(textUnmarshalerType) {
 				kv = reflect.New(kt)
 				if err := d.literalStore(item, kv, true); err != nil {
 					return err
 				}
 				kv = kv.Elem()
-			case kt.Kind() == reflect.String:
-				kv = reflect.ValueOf(key).Convert(kt)
-			default:
+			} else {
 				switch kt.Kind() {
+				case reflect.String:
+					kv = reflect.New(kt).Elem()
+					kv.SetString(string(key))
 				case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
 					s := string(key)
 					n, err := strconv.ParseInt(s, 10, 64)
-					if err != nil || reflect.Zero(kt).OverflowInt(n) {
+					if err != nil || kt.OverflowInt(n) {
 						d.saveError(&UnmarshalTypeError{Value: "number " + s, Type: kt, Offset: int64(start + 1)})
 						break
 					}
-					kv = reflect.ValueOf(n).Convert(kt)
+					kv = reflect.New(kt).Elem()
+					kv.SetInt(n)
 				case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
 					s := string(key)
 					n, err := strconv.ParseUint(s, 10, 64)
-					if err != nil || reflect.Zero(kt).OverflowUint(n) {
+					if err != nil || kt.OverflowUint(n) {
 						d.saveError(&UnmarshalTypeError{Value: "number " + s, Type: kt, Offset: int64(start + 1)})
 						break
 					}
-					kv = reflect.ValueOf(n).Convert(kt)
+					kv = reflect.New(kt).Elem()
+					kv.SetUint(n)
 				default:
 					panic("json: Unexpected key type") // should never occur
 				}
@@ -921,8 +811,6 @@ func (d *decodeState) object(v reflect.Value) error {
 			d.errorContext.FieldStack = d.errorContext.FieldStack[:len(origErrorContext.FieldStack)]
 			d.errorContext.Struct = origErrorContext.Struct
 		}
-		// Reset to original length and reuse the allocated space for the strict FieldStack slice.
-		d.strictFieldStack = d.strictFieldStack[:origStrictFieldStackLen]
 		if d.opcode == scanEndObject {
 			break
 		}
@@ -939,23 +827,14 @@ func (d *decodeState) convertNumber(s string) (any, error) {
 	if d.useNumber {
 		return Number(s), nil
 	}
-
-	// if the string contains no floating point, return it as an int64 if it decodes successfully and does not overflow.
-	// otherwise, fall back to float64 behavior.
-	if d.preserveInts && !strings.Contains(s, ".") {
-		if i, err := strconv.ParseInt(s, 10, 64); err == nil {
-			return i, nil
-		}
-	}
-
 	f, err := strconv.ParseFloat(s, 64)
 	if err != nil {
-		return nil, &UnmarshalTypeError{Value: "number " + s, Type: reflect.TypeOf(0.0), Offset: int64(d.off)}
+		return nil, &UnmarshalTypeError{Value: "number " + s, Type: reflect.TypeFor[float64](), Offset: int64(d.off)}
 	}
 	return f, nil
 }
 
-var numberType = reflect.TypeOf(Number(""))
+var numberType = reflect.TypeFor[Number]()
 
 // literalStore decodes a literal stored in item into v.
 //
@@ -965,7 +844,7 @@ var numberType = reflect.TypeOf(Number(""))
 func (d *decodeState) literalStore(item []byte, v reflect.Value, fromQuoted bool) error {
 	// Check for unmarshaler.
 	if len(item) == 0 {
-		//Empty string given
+		// Empty string given.
 		d.saveError(fmt.Errorf("json: invalid use of ,string struct tag, trying to unmarshal %q into %v", item, v.Type()))
 		return nil
 	}
@@ -1012,7 +891,7 @@ func (d *decodeState) literalStore(item []byte, v reflect.Value, fromQuoted bool
 		}
 		switch v.Kind() {
 		case reflect.Interface, reflect.Pointer, reflect.Map, reflect.Slice:
-			v.Set(reflect.Zero(v.Type()))
+			v.SetZero()
 			// otherwise, ignore null for primitives/string
 		}
 	case 't', 'f': // true, false
@@ -1064,10 +943,11 @@ func (d *decodeState) literalStore(item []byte, v reflect.Value, fromQuoted bool
 			}
 			v.SetBytes(b[:n])
 		case reflect.String:
-			if v.Type() == numberType && !isValidNumber(string(s)) {
+			t := string(s)
+			if v.Type() == numberType && !isValidNumber(t) {
 				return fmt.Errorf("json: invalid number literal, trying to unmarshal %q into Number", item)
 			}
-			v.SetString(string(s))
+			v.SetString(t)
 		case reflect.Interface:
 			if v.NumMethod() == 0 {
 				v.Set(reflect.ValueOf(string(s)))
@@ -1083,13 +963,12 @@ func (d *decodeState) literalStore(item []byte, v reflect.Value, fromQuoted bool
 			}
 			panic(phasePanicMsg)
 		}
-		s := string(item)
 		switch v.Kind() {
 		default:
 			if v.Kind() == reflect.String && v.Type() == numberType {
 				// s must be a valid number, because it's
 				// already been tokenized.
-				v.SetString(s)
+				v.SetString(string(item))
 				break
 			}
 			if fromQuoted {
@@ -1097,7 +976,7 @@ func (d *decodeState) literalStore(item []byte, v reflect.Value, fromQuoted bool
 			}
 			d.saveError(&UnmarshalTypeError{Value: "number", Type: v.Type(), Offset: int64(d.readIndex())})
 		case reflect.Interface:
-			n, err := d.convertNumber(s)
+			n, err := d.convertNumber(string(item))
 			if err != nil {
 				d.saveError(err)
 				break
@@ -1109,25 +988,25 @@ func (d *decodeState) literalStore(item []byte, v reflect.Value, fromQuoted bool
 			v.Set(reflect.ValueOf(n))
 
 		case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
-			n, err := strconv.ParseInt(s, 10, 64)
+			n, err := strconv.ParseInt(string(item), 10, 64)
 			if err != nil || v.OverflowInt(n) {
-				d.saveError(&UnmarshalTypeError{Value: "number " + s, Type: v.Type(), Offset: int64(d.readIndex())})
+				d.saveError(&UnmarshalTypeError{Value: "number " + string(item), Type: v.Type(), Offset: int64(d.readIndex())})
 				break
 			}
 			v.SetInt(n)
 
 		case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
-			n, err := strconv.ParseUint(s, 10, 64)
+			n, err := strconv.ParseUint(string(item), 10, 64)
 			if err != nil || v.OverflowUint(n) {
-				d.saveError(&UnmarshalTypeError{Value: "number " + s, Type: v.Type(), Offset: int64(d.readIndex())})
+				d.saveError(&UnmarshalTypeError{Value: "number " + string(item), Type: v.Type(), Offset: int64(d.readIndex())})
 				break
 			}
 			v.SetUint(n)
 
 		case reflect.Float32, reflect.Float64:
-			n, err := strconv.ParseFloat(s, v.Type().Bits())
+			n, err := strconv.ParseFloat(string(item), v.Type().Bits())
 			if err != nil || v.OverflowFloat(n) {
-				d.saveError(&UnmarshalTypeError{Value: "number " + s, Type: v.Type(), Offset: int64(d.readIndex())})
+				d.saveError(&UnmarshalTypeError{Value: "number " + string(item), Type: v.Type(), Offset: int64(d.readIndex())})
 				break
 			}
 			v.SetFloat(n)
@@ -1159,12 +1038,6 @@ func (d *decodeState) valueInterface() (val any) {
 
 // arrayInterface is like array but returns []interface{}.
 func (d *decodeState) arrayInterface() []any {
-	origStrictFieldStackLen := len(d.strictFieldStack)
-	defer func() {
-		// Reset to original length and reuse the allocated space for the strict FieldStack slice.
-		d.strictFieldStack = d.strictFieldStack[:origStrictFieldStackLen]
-	}()
-
 	var v = make([]any, 0)
 	for {
 		// Look ahead for ] - can only happen on first iteration.
@@ -1173,10 +1046,7 @@ func (d *decodeState) arrayInterface() []any {
 			break
 		}
 
-		d.appendStrictFieldStackIndex(len(v))
 		v = append(v, d.valueInterface())
-		// Reset to original length and reuse the allocated space for the strict FieldStack slice.
-		d.strictFieldStack = d.strictFieldStack[:origStrictFieldStackLen]
 
 		// Next token must be , or ].
 		if d.opcode == scanSkipSpace {
@@ -1194,12 +1064,6 @@ func (d *decodeState) arrayInterface() []any {
 
 // objectInterface is like object but returns map[string]interface{}.
 func (d *decodeState) objectInterface() map[string]any {
-	origStrictFieldStackLen := len(d.strictFieldStack)
-	defer func() {
-		// Reset to original length and reuse the allocated space for the strict FieldStack slice.
-		d.strictFieldStack = d.strictFieldStack[:origStrictFieldStackLen]
-	}()
-
 	m := make(map[string]any)
 	for {
 		// Read opening " of string key or closing }.
@@ -1230,17 +1094,8 @@ func (d *decodeState) objectInterface() map[string]any {
 		}
 		d.scanWhile(scanSkipSpace)
 
-		if d.disallowDuplicateFields {
-			if _, exists := m[key]; exists {
-				d.saveStrictError(d.newFieldError(duplicateStrictErrType, key))
-			}
-		}
-
 		// Read value.
-		d.appendStrictFieldStackKey(key)
 		m[key] = d.valueInterface()
-		// Reset to original length and reuse the allocated space for the strict FieldStack slice.
-		d.strictFieldStack = d.strictFieldStack[:origStrictFieldStackLen]
 
 		// Next token must be , or }.
 		if d.opcode == scanSkipSpace {
@@ -1323,6 +1178,15 @@ func unquote(s []byte) (t string, ok bool) {
 	return
 }
 
+// unquoteBytes should be an internal detail,
+// but widely used packages access it using linkname.
+// Notable members of the hall of shame include:
+//   - github.com/bytedance/sonic
+//
+// Do not remove or change the type signature.
+// See go.dev/issue/67401.
+//
+//go:linkname unquoteBytes
 func unquoteBytes(s []byte) (t []byte, ok bool) {
 	if len(s) < 2 || s[0] != '"' || s[len(s)-1] != '"' {
 		return

--- a/internal/golang/encoding/json/decode_test.go
+++ b/internal/golang/encoding/json/decode_test.go
@@ -946,7 +946,7 @@ var unmarshalTests = []struct {
 			"Q": 18
 		}`,
 		ptr:                   new(Top),
-		err:                   fmt.Errorf("json: unknown field \"extra\""),
+		err:                   fmt.Errorf("json: unknown field \"e.extra\""),
 		disallowUnknownFields: true,
 	},
 	// issue 26444

--- a/internal/golang/encoding/json/decode_test.go
+++ b/internal/golang/encoding/json/decode_test.go
@@ -14,6 +14,7 @@ import (
 	"math/big"
 	"net"
 	"reflect"
+	"slices"
 	"strconv"
 	"strings"
 	"testing"
@@ -57,7 +58,7 @@ type PP struct {
 type SS string
 
 func (*SS) UnmarshalJSON(data []byte) error {
-	return &UnmarshalTypeError{Value: "number", Type: reflect.TypeOf(SS(""))}
+	return &UnmarshalTypeError{Value: "number", Type: reflect.TypeFor[SS]()}
 }
 
 // ifaceNumAsFloat64/ifaceNumAsNumber are used to test unmarshaling with and
@@ -387,16 +388,6 @@ type mapStringToStringData struct {
 	Data map[string]string `json:"data"`
 }
 
-type unmarshalTest struct {
-	in                    string
-	ptr                   any // new(type)
-	out                   any
-	err                   error
-	useNumber             bool
-	golden                bool
-	disallowUnknownFields bool
-}
-
 type B struct {
 	B bool `json:",string"`
 }
@@ -406,179 +397,203 @@ type DoublePtr struct {
 	J **int
 }
 
-var unmarshalTests = []unmarshalTest{
+var unmarshalTests = []struct {
+	CaseName
+	in                    string
+	ptr                   any // new(type)
+	out                   any
+	err                   error
+	useNumber             bool
+	golden                bool
+	disallowUnknownFields bool
+}{
 	// basic types
-	{in: `true`, ptr: new(bool), out: true},
-	{in: `1`, ptr: new(int), out: 1},
-	{in: `1.2`, ptr: new(float64), out: 1.2},
-	{in: `-5`, ptr: new(int16), out: int16(-5)},
-	{in: `2`, ptr: new(Number), out: Number("2"), useNumber: true},
-	{in: `2`, ptr: new(Number), out: Number("2")},
-	{in: `2`, ptr: new(any), out: float64(2.0)},
-	{in: `2`, ptr: new(any), out: Number("2"), useNumber: true},
-	{in: `"a\u1234"`, ptr: new(string), out: "a\u1234"},
-	{in: `"http:\/\/"`, ptr: new(string), out: "http://"},
-	{in: `"g-clef: \uD834\uDD1E"`, ptr: new(string), out: "g-clef: \U0001D11E"},
-	{in: `"invalid: \uD834x\uDD1E"`, ptr: new(string), out: "invalid: \uFFFDx\uFFFD"},
-	{in: "null", ptr: new(any), out: nil},
-	{in: `{"X": [1,2,3], "Y": 4}`, ptr: new(T), out: T{Y: 4}, err: &UnmarshalTypeError{"array", reflect.TypeOf(""), 7, "T", "X"}},
-	{in: `{"X": 23}`, ptr: new(T), out: T{}, err: &UnmarshalTypeError{"number", reflect.TypeOf(""), 8, "T", "X"}}, {in: `{"x": 1}`, ptr: new(tx), out: tx{}},
-	{in: `{"x": 1}`, ptr: new(tx), out: tx{}},
-	{in: `{"x": 1}`, ptr: new(tx), err: fmt.Errorf("json: unknown field \"x\""), disallowUnknownFields: true},
-	{in: `{"S": 23}`, ptr: new(W), out: W{}, err: &UnmarshalTypeError{"number", reflect.TypeOf(SS("")), 0, "W", "S"}},
-	{in: `{"F1":1,"F2":2,"F3":3}`, ptr: new(V), out: V{F1: float64(1), F2: int32(2), F3: Number("3")}},
-	{in: `{"F1":1,"F2":2,"F3":3}`, ptr: new(V), out: V{F1: Number("1"), F2: int32(2), F3: Number("3")}, useNumber: true},
-	{in: `{"k1":1,"k2":"s","k3":[1,2.0,3e-3],"k4":{"kk1":"s","kk2":2}}`, ptr: new(any), out: ifaceNumAsFloat64},
-	{in: `{"k1":1,"k2":"s","k3":[1,2.0,3e-3],"k4":{"kk1":"s","kk2":2}}`, ptr: new(any), out: ifaceNumAsNumber, useNumber: true},
+	{CaseName: Name(""), in: `true`, ptr: new(bool), out: true},
+	{CaseName: Name(""), in: `1`, ptr: new(int), out: 1},
+	{CaseName: Name(""), in: `1.2`, ptr: new(float64), out: 1.2},
+	{CaseName: Name(""), in: `-5`, ptr: new(int16), out: int16(-5)},
+	{CaseName: Name(""), in: `2`, ptr: new(Number), out: Number("2"), useNumber: true},
+	{CaseName: Name(""), in: `2`, ptr: new(Number), out: Number("2")},
+	{CaseName: Name(""), in: `2`, ptr: new(any), out: float64(2.0)},
+	{CaseName: Name(""), in: `2`, ptr: new(any), out: Number("2"), useNumber: true},
+	{CaseName: Name(""), in: `"a\u1234"`, ptr: new(string), out: "a\u1234"},
+	{CaseName: Name(""), in: `"http:\/\/"`, ptr: new(string), out: "http://"},
+	{CaseName: Name(""), in: `"g-clef: \uD834\uDD1E"`, ptr: new(string), out: "g-clef: \U0001D11E"},
+	{CaseName: Name(""), in: `"invalid: \uD834x\uDD1E"`, ptr: new(string), out: "invalid: \uFFFDx\uFFFD"},
+	{CaseName: Name(""), in: "null", ptr: new(any), out: nil},
+	{CaseName: Name(""), in: `{"X": [1,2,3], "Y": 4}`, ptr: new(T), out: T{Y: 4}, err: &UnmarshalTypeError{"array", reflect.TypeFor[string](), 7, "T", "X"}},
+	{CaseName: Name(""), in: `{"X": 23}`, ptr: new(T), out: T{}, err: &UnmarshalTypeError{"number", reflect.TypeFor[string](), 8, "T", "X"}},
+	{CaseName: Name(""), in: `{"x": 1}`, ptr: new(tx), out: tx{}},
+	{CaseName: Name(""), in: `{"x": 1}`, ptr: new(tx), out: tx{}},
+	{CaseName: Name(""), in: `{"x": 1}`, ptr: new(tx), err: fmt.Errorf("json: unknown field \"x\""), disallowUnknownFields: true},
+	{CaseName: Name(""), in: `{"S": 23}`, ptr: new(W), out: W{}, err: &UnmarshalTypeError{"number", reflect.TypeFor[SS](), 0, "W", "S"}},
+	{CaseName: Name(""), in: `{"F1":1,"F2":2,"F3":3}`, ptr: new(V), out: V{F1: float64(1), F2: int32(2), F3: Number("3")}},
+	{CaseName: Name(""), in: `{"F1":1,"F2":2,"F3":3}`, ptr: new(V), out: V{F1: Number("1"), F2: int32(2), F3: Number("3")}, useNumber: true},
+	{CaseName: Name(""), in: `{"k1":1,"k2":"s","k3":[1,2.0,3e-3],"k4":{"kk1":"s","kk2":2}}`, ptr: new(any), out: ifaceNumAsFloat64},
+	{CaseName: Name(""), in: `{"k1":1,"k2":"s","k3":[1,2.0,3e-3],"k4":{"kk1":"s","kk2":2}}`, ptr: new(any), out: ifaceNumAsNumber, useNumber: true},
 
 	// raw values with whitespace
-	{in: "\n true ", ptr: new(bool), out: true},
-	{in: "\t 1 ", ptr: new(int), out: 1},
-	{in: "\r 1.2 ", ptr: new(float64), out: 1.2},
-	{in: "\t -5 \n", ptr: new(int16), out: int16(-5)},
-	{in: "\t \"a\\u1234\" \n", ptr: new(string), out: "a\u1234"},
+	{CaseName: Name(""), in: "\n true ", ptr: new(bool), out: true},
+	{CaseName: Name(""), in: "\t 1 ", ptr: new(int), out: 1},
+	{CaseName: Name(""), in: "\r 1.2 ", ptr: new(float64), out: 1.2},
+	{CaseName: Name(""), in: "\t -5 \n", ptr: new(int16), out: int16(-5)},
+	{CaseName: Name(""), in: "\t \"a\\u1234\" \n", ptr: new(string), out: "a\u1234"},
 
 	// Z has a "-" tag.
-	{in: `{"Y": 1, "Z": 2}`, ptr: new(T), out: T{Y: 1}},
-	{in: `{"Y": 1, "Z": 2}`, ptr: new(T), err: fmt.Errorf("json: unknown field \"Z\""), disallowUnknownFields: true},
+	{CaseName: Name(""), in: `{"Y": 1, "Z": 2}`, ptr: new(T), out: T{Y: 1}},
+	{CaseName: Name(""), in: `{"Y": 1, "Z": 2}`, ptr: new(T), err: fmt.Errorf("json: unknown field \"Z\""), disallowUnknownFields: true},
 
-	{in: `{"alpha": "abc", "alphabet": "xyz"}`, ptr: new(U), out: U{Alphabet: "abc"}},
-	{in: `{"alpha": "abc", "alphabet": "xyz"}`, ptr: new(U), err: fmt.Errorf("json: unknown field \"alphabet\""), disallowUnknownFields: true},
-	{in: `{"alpha": "abc"}`, ptr: new(U), out: U{Alphabet: "abc"}},
-	{in: `{"alphabet": "xyz"}`, ptr: new(U), out: U{}},
-	{in: `{"alphabet": "xyz"}`, ptr: new(U), err: fmt.Errorf("json: unknown field \"alphabet\""), disallowUnknownFields: true},
+	{CaseName: Name(""), in: `{"alpha": "abc", "alphabet": "xyz"}`, ptr: new(U), out: U{Alphabet: "abc"}},
+	{CaseName: Name(""), in: `{"alpha": "abc", "alphabet": "xyz"}`, ptr: new(U), err: fmt.Errorf("json: unknown field \"alphabet\""), disallowUnknownFields: true},
+	{CaseName: Name(""), in: `{"alpha": "abc"}`, ptr: new(U), out: U{Alphabet: "abc"}},
+	{CaseName: Name(""), in: `{"alphabet": "xyz"}`, ptr: new(U), out: U{}},
+	{CaseName: Name(""), in: `{"alphabet": "xyz"}`, ptr: new(U), err: fmt.Errorf("json: unknown field \"alphabet\""), disallowUnknownFields: true},
 
 	// syntax errors
-	{in: `{"X": "foo", "Y"}`, err: &SyntaxError{"invalid character '}' after object key", 17}},
-	{in: `[1, 2, 3+]`, err: &SyntaxError{"invalid character '+' after array element", 9}},
-	{in: `{"X":12x}`, err: &SyntaxError{"invalid character 'x' after object key:value pair", 8}, useNumber: true},
-	{in: `[2, 3`, err: &SyntaxError{msg: "unexpected end of JSON input", Offset: 5}},
-	{in: `{"F3": -}`, ptr: new(V), out: V{F3: Number("-")}, err: &SyntaxError{msg: "invalid character '}' in numeric literal", Offset: 9}},
+	{CaseName: Name(""), in: `{"X": "foo", "Y"}`, err: &SyntaxError{"invalid character '}' after object key", 17}},
+	{CaseName: Name(""), in: `[1, 2, 3+]`, err: &SyntaxError{"invalid character '+' after array element", 9}},
+	{CaseName: Name(""), in: `{"X":12x}`, err: &SyntaxError{"invalid character 'x' after object key:value pair", 8}, useNumber: true},
+	{CaseName: Name(""), in: `[2, 3`, err: &SyntaxError{msg: "unexpected end of JSON input", Offset: 5}},
+	{CaseName: Name(""), in: `{"F3": -}`, ptr: new(V), out: V{F3: Number("-")}, err: &SyntaxError{msg: "invalid character '}' in numeric literal", Offset: 9}},
 
 	// raw value errors
-	{in: "\x01 42", err: &SyntaxError{"invalid character '\\x01' looking for beginning of value", 1}},
-	{in: " 42 \x01", err: &SyntaxError{"invalid character '\\x01' after top-level value", 5}},
-	{in: "\x01 true", err: &SyntaxError{"invalid character '\\x01' looking for beginning of value", 1}},
-	{in: " false \x01", err: &SyntaxError{"invalid character '\\x01' after top-level value", 8}},
-	{in: "\x01 1.2", err: &SyntaxError{"invalid character '\\x01' looking for beginning of value", 1}},
-	{in: " 3.4 \x01", err: &SyntaxError{"invalid character '\\x01' after top-level value", 6}},
-	{in: "\x01 \"string\"", err: &SyntaxError{"invalid character '\\x01' looking for beginning of value", 1}},
-	{in: " \"string\" \x01", err: &SyntaxError{"invalid character '\\x01' after top-level value", 11}},
+	{CaseName: Name(""), in: "\x01 42", err: &SyntaxError{"invalid character '\\x01' looking for beginning of value", 1}},
+	{CaseName: Name(""), in: " 42 \x01", err: &SyntaxError{"invalid character '\\x01' after top-level value", 5}},
+	{CaseName: Name(""), in: "\x01 true", err: &SyntaxError{"invalid character '\\x01' looking for beginning of value", 1}},
+	{CaseName: Name(""), in: " false \x01", err: &SyntaxError{"invalid character '\\x01' after top-level value", 8}},
+	{CaseName: Name(""), in: "\x01 1.2", err: &SyntaxError{"invalid character '\\x01' looking for beginning of value", 1}},
+	{CaseName: Name(""), in: " 3.4 \x01", err: &SyntaxError{"invalid character '\\x01' after top-level value", 6}},
+	{CaseName: Name(""), in: "\x01 \"string\"", err: &SyntaxError{"invalid character '\\x01' looking for beginning of value", 1}},
+	{CaseName: Name(""), in: " \"string\" \x01", err: &SyntaxError{"invalid character '\\x01' after top-level value", 11}},
 
 	// array tests
-	{in: `[1, 2, 3]`, ptr: new([3]int), out: [3]int{1, 2, 3}},
-	{in: `[1, 2, 3]`, ptr: new([1]int), out: [1]int{1}},
-	{in: `[1, 2, 3]`, ptr: new([5]int), out: [5]int{1, 2, 3, 0, 0}},
-	{in: `[1, 2, 3]`, ptr: new(MustNotUnmarshalJSON), err: errors.New("MustNotUnmarshalJSON was used")},
+	{CaseName: Name(""), in: `[1, 2, 3]`, ptr: new([3]int), out: [3]int{1, 2, 3}},
+	{CaseName: Name(""), in: `[1, 2, 3]`, ptr: new([1]int), out: [1]int{1}},
+	{CaseName: Name(""), in: `[1, 2, 3]`, ptr: new([5]int), out: [5]int{1, 2, 3, 0, 0}},
+	{CaseName: Name(""), in: `[1, 2, 3]`, ptr: new(MustNotUnmarshalJSON), err: errors.New("MustNotUnmarshalJSON was used")},
 
 	// empty array to interface test
-	{in: `[]`, ptr: new([]any), out: []any{}},
-	{in: `null`, ptr: new([]any), out: []any(nil)},
-	{in: `{"T":[]}`, ptr: new(map[string]any), out: map[string]any{"T": []any{}}},
-	{in: `{"T":null}`, ptr: new(map[string]any), out: map[string]any{"T": any(nil)}},
+	{CaseName: Name(""), in: `[]`, ptr: new([]any), out: []any{}},
+	{CaseName: Name(""), in: `null`, ptr: new([]any), out: []any(nil)},
+	{CaseName: Name(""), in: `{"T":[]}`, ptr: new(map[string]any), out: map[string]any{"T": []any{}}},
+	{CaseName: Name(""), in: `{"T":null}`, ptr: new(map[string]any), out: map[string]any{"T": any(nil)}},
 
 	// composite tests
-	{in: allValueIndent, ptr: new(All), out: allValue},
-	{in: allValueCompact, ptr: new(All), out: allValue},
-	{in: allValueIndent, ptr: new(*All), out: &allValue},
-	{in: allValueCompact, ptr: new(*All), out: &allValue},
-	{in: pallValueIndent, ptr: new(All), out: pallValue},
-	{in: pallValueCompact, ptr: new(All), out: pallValue},
-	{in: pallValueIndent, ptr: new(*All), out: &pallValue},
-	{in: pallValueCompact, ptr: new(*All), out: &pallValue},
+	{CaseName: Name(""), in: allValueIndent, ptr: new(All), out: allValue},
+	{CaseName: Name(""), in: allValueCompact, ptr: new(All), out: allValue},
+	{CaseName: Name(""), in: allValueIndent, ptr: new(*All), out: &allValue},
+	{CaseName: Name(""), in: allValueCompact, ptr: new(*All), out: &allValue},
+	{CaseName: Name(""), in: pallValueIndent, ptr: new(All), out: pallValue},
+	{CaseName: Name(""), in: pallValueCompact, ptr: new(All), out: pallValue},
+	{CaseName: Name(""), in: pallValueIndent, ptr: new(*All), out: &pallValue},
+	{CaseName: Name(""), in: pallValueCompact, ptr: new(*All), out: &pallValue},
 
 	// unmarshal interface test
-	{in: `{"T":false}`, ptr: new(unmarshaler), out: umtrue}, // use "false" so test will fail if custom unmarshaler is not called
-	{in: `{"T":false}`, ptr: new(*unmarshaler), out: &umtrue},
-	{in: `[{"T":false}]`, ptr: new([]unmarshaler), out: umslice},
-	{in: `[{"T":false}]`, ptr: new(*[]unmarshaler), out: &umslice},
-	{in: `{"M":{"T":"x:y"}}`, ptr: new(ustruct), out: umstruct},
+	{CaseName: Name(""), in: `{"T":false}`, ptr: new(unmarshaler), out: umtrue}, // use "false" so test will fail if custom unmarshaler is not called
+	{CaseName: Name(""), in: `{"T":false}`, ptr: new(*unmarshaler), out: &umtrue},
+	{CaseName: Name(""), in: `[{"T":false}]`, ptr: new([]unmarshaler), out: umslice},
+	{CaseName: Name(""), in: `[{"T":false}]`, ptr: new(*[]unmarshaler), out: &umslice},
+	{CaseName: Name(""), in: `{"M":{"T":"x:y"}}`, ptr: new(ustruct), out: umstruct},
 
 	// UnmarshalText interface test
-	{in: `"x:y"`, ptr: new(unmarshalerText), out: umtrueXY},
-	{in: `"x:y"`, ptr: new(*unmarshalerText), out: &umtrueXY},
-	{in: `["x:y"]`, ptr: new([]unmarshalerText), out: umsliceXY},
-	{in: `["x:y"]`, ptr: new(*[]unmarshalerText), out: &umsliceXY},
-	{in: `{"M":"x:y"}`, ptr: new(ustructText), out: umstructXY},
+	{CaseName: Name(""), in: `"x:y"`, ptr: new(unmarshalerText), out: umtrueXY},
+	{CaseName: Name(""), in: `"x:y"`, ptr: new(*unmarshalerText), out: &umtrueXY},
+	{CaseName: Name(""), in: `["x:y"]`, ptr: new([]unmarshalerText), out: umsliceXY},
+	{CaseName: Name(""), in: `["x:y"]`, ptr: new(*[]unmarshalerText), out: &umsliceXY},
+	{CaseName: Name(""), in: `{"M":"x:y"}`, ptr: new(ustructText), out: umstructXY},
 
 	// integer-keyed map test
 	{
-		in:  `{"-1":"a","0":"b","1":"c"}`,
-		ptr: new(map[int]string),
-		out: map[int]string{-1: "a", 0: "b", 1: "c"},
+		CaseName: Name(""),
+		in:       `{"-1":"a","0":"b","1":"c"}`,
+		ptr:      new(map[int]string),
+		out:      map[int]string{-1: "a", 0: "b", 1: "c"},
 	},
 	{
-		in:  `{"0":"a","10":"c","9":"b"}`,
-		ptr: new(map[u8]string),
-		out: map[u8]string{0: "a", 9: "b", 10: "c"},
+		CaseName: Name(""),
+		in:       `{"0":"a","10":"c","9":"b"}`,
+		ptr:      new(map[u8]string),
+		out:      map[u8]string{0: "a", 9: "b", 10: "c"},
 	},
 	{
-		in:  `{"-9223372036854775808":"min","9223372036854775807":"max"}`,
-		ptr: new(map[int64]string),
-		out: map[int64]string{math.MinInt64: "min", math.MaxInt64: "max"},
+		CaseName: Name(""),
+		in:       `{"-9223372036854775808":"min","9223372036854775807":"max"}`,
+		ptr:      new(map[int64]string),
+		out:      map[int64]string{math.MinInt64: "min", math.MaxInt64: "max"},
 	},
 	{
-		in:  `{"18446744073709551615":"max"}`,
-		ptr: new(map[uint64]string),
-		out: map[uint64]string{math.MaxUint64: "max"},
+		CaseName: Name(""),
+		in:       `{"18446744073709551615":"max"}`,
+		ptr:      new(map[uint64]string),
+		out:      map[uint64]string{math.MaxUint64: "max"},
 	},
 	{
-		in:  `{"0":false,"10":true}`,
-		ptr: new(map[uintptr]bool),
-		out: map[uintptr]bool{0: false, 10: true},
+		CaseName: Name(""),
+		in:       `{"0":false,"10":true}`,
+		ptr:      new(map[uintptr]bool),
+		out:      map[uintptr]bool{0: false, 10: true},
 	},
 
 	// Check that MarshalText and UnmarshalText take precedence
 	// over default integer handling in map keys.
 	{
-		in:  `{"u2":4}`,
-		ptr: new(map[u8marshal]int),
-		out: map[u8marshal]int{2: 4},
+		CaseName: Name(""),
+		in:       `{"u2":4}`,
+		ptr:      new(map[u8marshal]int),
+		out:      map[u8marshal]int{2: 4},
 	},
 	{
-		in:  `{"2":4}`,
-		ptr: new(map[u8marshal]int),
-		err: errMissingU8Prefix,
+		CaseName: Name(""),
+		in:       `{"2":4}`,
+		ptr:      new(map[u8marshal]int),
+		err:      errMissingU8Prefix,
 	},
 
 	// integer-keyed map errors
 	{
-		in:  `{"abc":"abc"}`,
-		ptr: new(map[int]string),
-		err: &UnmarshalTypeError{Value: "number abc", Type: reflect.TypeOf(0), Offset: 2},
+		CaseName: Name(""),
+		in:       `{"abc":"abc"}`,
+		ptr:      new(map[int]string),
+		err:      &UnmarshalTypeError{Value: "number abc", Type: reflect.TypeFor[int](), Offset: 2},
 	},
 	{
-		in:  `{"256":"abc"}`,
-		ptr: new(map[uint8]string),
-		err: &UnmarshalTypeError{Value: "number 256", Type: reflect.TypeOf(uint8(0)), Offset: 2},
+		CaseName: Name(""),
+		in:       `{"256":"abc"}`,
+		ptr:      new(map[uint8]string),
+		err:      &UnmarshalTypeError{Value: "number 256", Type: reflect.TypeFor[uint8](), Offset: 2},
 	},
 	{
-		in:  `{"128":"abc"}`,
-		ptr: new(map[int8]string),
-		err: &UnmarshalTypeError{Value: "number 128", Type: reflect.TypeOf(int8(0)), Offset: 2},
+		CaseName: Name(""),
+		in:       `{"128":"abc"}`,
+		ptr:      new(map[int8]string),
+		err:      &UnmarshalTypeError{Value: "number 128", Type: reflect.TypeFor[int8](), Offset: 2},
 	},
 	{
-		in:  `{"-1":"abc"}`,
-		ptr: new(map[uint8]string),
-		err: &UnmarshalTypeError{Value: "number -1", Type: reflect.TypeOf(uint8(0)), Offset: 2},
+		CaseName: Name(""),
+		in:       `{"-1":"abc"}`,
+		ptr:      new(map[uint8]string),
+		err:      &UnmarshalTypeError{Value: "number -1", Type: reflect.TypeFor[uint8](), Offset: 2},
 	},
 	{
-		in:  `{"F":{"a":2,"3":4}}`,
-		ptr: new(map[string]map[int]int),
-		err: &UnmarshalTypeError{Value: "number a", Type: reflect.TypeOf(int(0)), Offset: 7},
+		CaseName: Name(""),
+		in:       `{"F":{"a":2,"3":4}}`,
+		ptr:      new(map[string]map[int]int),
+		err:      &UnmarshalTypeError{Value: "number a", Type: reflect.TypeFor[int](), Offset: 7},
 	},
 	{
-		in:  `{"F":{"a":2,"3":4}}`,
-		ptr: new(map[string]map[uint]int),
-		err: &UnmarshalTypeError{Value: "number a", Type: reflect.TypeOf(uint(0)), Offset: 7},
+		CaseName: Name(""),
+		in:       `{"F":{"a":2,"3":4}}`,
+		ptr:      new(map[string]map[uint]int),
+		err:      &UnmarshalTypeError{Value: "number a", Type: reflect.TypeFor[uint](), Offset: 7},
 	},
 
 	// Map keys can be encoding.TextUnmarshalers.
-	{in: `{"x:y":true}`, ptr: new(map[unmarshalerText]bool), out: ummapXY},
+	{CaseName: Name(""), in: `{"x:y":true}`, ptr: new(map[unmarshalerText]bool), out: ummapXY},
 	// If multiple values for the same key exists, only the most recent value is used.
-	{in: `{"x:y":false,"x:y":true}`, ptr: new(map[unmarshalerText]bool), out: ummapXY},
+	{CaseName: Name(""), in: `{"x:y":false,"x:y":true}`, ptr: new(map[unmarshalerText]bool), out: ummapXY},
 
 	{
+		CaseName: Name(""),
 		in: `{
 			"Level0": 1,
 			"Level1b": 2,
@@ -634,93 +649,109 @@ var unmarshalTests = []unmarshalTest{
 		},
 	},
 	{
-		in:  `{"hello": 1}`,
-		ptr: new(Ambig),
-		out: Ambig{First: 1},
+		CaseName: Name(""),
+		in:       `{"hello": 1}`,
+		ptr:      new(Ambig),
+		out:      Ambig{First: 1},
 	},
 
 	{
-		in:  `{"X": 1,"Y":2}`,
-		ptr: new(S5),
-		out: S5{S8: S8{S9: S9{Y: 2}}},
+		CaseName: Name(""),
+		in:       `{"X": 1,"Y":2}`,
+		ptr:      new(S5),
+		out:      S5{S8: S8{S9: S9{Y: 2}}},
 	},
 	{
+		CaseName:              Name(""),
 		in:                    `{"X": 1,"Y":2}`,
 		ptr:                   new(S5),
 		err:                   fmt.Errorf("json: unknown field \"X\""),
 		disallowUnknownFields: true,
 	},
 	{
-		in:  `{"X": 1,"Y":2}`,
-		ptr: new(S10),
-		out: S10{S13: S13{S8: S8{S9: S9{Y: 2}}}},
+		CaseName: Name(""),
+		in:       `{"X": 1,"Y":2}`,
+		ptr:      new(S10),
+		out:      S10{S13: S13{S8: S8{S9: S9{Y: 2}}}},
 	},
 	{
+		CaseName:              Name(""),
 		in:                    `{"X": 1,"Y":2}`,
 		ptr:                   new(S10),
 		err:                   fmt.Errorf("json: unknown field \"X\""),
 		disallowUnknownFields: true,
 	},
 	{
-		in:  `{"I": 0, "I": null, "J": null}`,
-		ptr: new(DoublePtr),
-		out: DoublePtr{I: nil, J: nil},
+		CaseName: Name(""),
+		in:       `{"I": 0, "I": null, "J": null}`,
+		ptr:      new(DoublePtr),
+		out:      DoublePtr{I: nil, J: nil},
 	},
 
 	// invalid UTF-8 is coerced to valid UTF-8.
 	{
-		in:  "\"hello\xffworld\"",
-		ptr: new(string),
-		out: "hello\ufffdworld",
+		CaseName: Name(""),
+		in:       "\"hello\xffworld\"",
+		ptr:      new(string),
+		out:      "hello\ufffdworld",
 	},
 	{
-		in:  "\"hello\xc2\xc2world\"",
-		ptr: new(string),
-		out: "hello\ufffd\ufffdworld",
+		CaseName: Name(""),
+		in:       "\"hello\xc2\xc2world\"",
+		ptr:      new(string),
+		out:      "hello\ufffd\ufffdworld",
 	},
 	{
-		in:  "\"hello\xc2\xffworld\"",
-		ptr: new(string),
-		out: "hello\ufffd\ufffdworld",
+		CaseName: Name(""),
+		in:       "\"hello\xc2\xffworld\"",
+		ptr:      new(string),
+		out:      "hello\ufffd\ufffdworld",
 	},
 	{
-		in:  "\"hello\\ud800world\"",
-		ptr: new(string),
-		out: "hello\ufffdworld",
+		CaseName: Name(""),
+		in:       "\"hello\\ud800world\"",
+		ptr:      new(string),
+		out:      "hello\ufffdworld",
 	},
 	{
-		in:  "\"hello\\ud800\\ud800world\"",
-		ptr: new(string),
-		out: "hello\ufffd\ufffdworld",
+		CaseName: Name(""),
+		in:       "\"hello\\ud800\\ud800world\"",
+		ptr:      new(string),
+		out:      "hello\ufffd\ufffdworld",
 	},
 	{
-		in:  "\"hello\\ud800\\ud800world\"",
-		ptr: new(string),
-		out: "hello\ufffd\ufffdworld",
+		CaseName: Name(""),
+		in:       "\"hello\\ud800\\ud800world\"",
+		ptr:      new(string),
+		out:      "hello\ufffd\ufffdworld",
 	},
 	{
-		in:  "\"hello\xed\xa0\x80\xed\xb0\x80world\"",
-		ptr: new(string),
-		out: "hello\ufffd\ufffd\ufffd\ufffd\ufffd\ufffdworld",
+		CaseName: Name(""),
+		in:       "\"hello\xed\xa0\x80\xed\xb0\x80world\"",
+		ptr:      new(string),
+		out:      "hello\ufffd\ufffd\ufffd\ufffd\ufffd\ufffdworld",
 	},
 
 	// Used to be issue 8305, but time.Time implements encoding.TextUnmarshaler so this works now.
 	{
-		in:  `{"2009-11-10T23:00:00Z": "hello world"}`,
-		ptr: new(map[time.Time]string),
-		out: map[time.Time]string{time.Date(2009, 11, 10, 23, 0, 0, 0, time.UTC): "hello world"},
+		CaseName: Name(""),
+		in:       `{"2009-11-10T23:00:00Z": "hello world"}`,
+		ptr:      new(map[time.Time]string),
+		out:      map[time.Time]string{time.Date(2009, 11, 10, 23, 0, 0, 0, time.UTC): "hello world"},
 	},
 
 	// issue 8305
 	{
-		in:  `{"2009-11-10T23:00:00Z": "hello world"}`,
-		ptr: new(map[Point]string),
-		err: &UnmarshalTypeError{Value: "object", Type: reflect.TypeOf(map[Point]string{}), Offset: 1},
+		CaseName: Name(""),
+		in:       `{"2009-11-10T23:00:00Z": "hello world"}`,
+		ptr:      new(map[Point]string),
+		err:      &UnmarshalTypeError{Value: "object", Type: reflect.TypeFor[map[Point]string](), Offset: 1},
 	},
 	{
-		in:  `{"asdf": "hello world"}`,
-		ptr: new(map[unmarshaler]string),
-		err: &UnmarshalTypeError{Value: "object", Type: reflect.TypeOf(map[unmarshaler]string{}), Offset: 1},
+		CaseName: Name(""),
+		in:       `{"asdf": "hello world"}`,
+		ptr:      new(map[unmarshaler]string),
+		err:      &UnmarshalTypeError{Value: "object", Type: reflect.TypeFor[map[unmarshaler]string](), Offset: 1},
 	},
 
 	// related to issue 13783.
@@ -731,124 +762,139 @@ var unmarshalTests = []unmarshalTest{
 	// successfully unmarshaled. The custom unmarshalers were accessible in earlier
 	// versions of Go, even though the custom marshaler was not.
 	{
-		in:  `"AQID"`,
-		ptr: new([]byteWithMarshalJSON),
-		out: []byteWithMarshalJSON{1, 2, 3},
+		CaseName: Name(""),
+		in:       `"AQID"`,
+		ptr:      new([]byteWithMarshalJSON),
+		out:      []byteWithMarshalJSON{1, 2, 3},
 	},
 	{
-		in:     `["Z01","Z02","Z03"]`,
-		ptr:    new([]byteWithMarshalJSON),
-		out:    []byteWithMarshalJSON{1, 2, 3},
-		golden: true,
+		CaseName: Name(""),
+		in:       `["Z01","Z02","Z03"]`,
+		ptr:      new([]byteWithMarshalJSON),
+		out:      []byteWithMarshalJSON{1, 2, 3},
+		golden:   true,
 	},
 	{
-		in:  `"AQID"`,
-		ptr: new([]byteWithMarshalText),
-		out: []byteWithMarshalText{1, 2, 3},
+		CaseName: Name(""),
+		in:       `"AQID"`,
+		ptr:      new([]byteWithMarshalText),
+		out:      []byteWithMarshalText{1, 2, 3},
 	},
 	{
-		in:     `["Z01","Z02","Z03"]`,
-		ptr:    new([]byteWithMarshalText),
-		out:    []byteWithMarshalText{1, 2, 3},
-		golden: true,
+		CaseName: Name(""),
+		in:       `["Z01","Z02","Z03"]`,
+		ptr:      new([]byteWithMarshalText),
+		out:      []byteWithMarshalText{1, 2, 3},
+		golden:   true,
 	},
 	{
-		in:  `"AQID"`,
-		ptr: new([]byteWithPtrMarshalJSON),
-		out: []byteWithPtrMarshalJSON{1, 2, 3},
+		CaseName: Name(""),
+		in:       `"AQID"`,
+		ptr:      new([]byteWithPtrMarshalJSON),
+		out:      []byteWithPtrMarshalJSON{1, 2, 3},
 	},
 	{
-		in:     `["Z01","Z02","Z03"]`,
-		ptr:    new([]byteWithPtrMarshalJSON),
-		out:    []byteWithPtrMarshalJSON{1, 2, 3},
-		golden: true,
+		CaseName: Name(""),
+		in:       `["Z01","Z02","Z03"]`,
+		ptr:      new([]byteWithPtrMarshalJSON),
+		out:      []byteWithPtrMarshalJSON{1, 2, 3},
+		golden:   true,
 	},
 	{
-		in:  `"AQID"`,
-		ptr: new([]byteWithPtrMarshalText),
-		out: []byteWithPtrMarshalText{1, 2, 3},
+		CaseName: Name(""),
+		in:       `"AQID"`,
+		ptr:      new([]byteWithPtrMarshalText),
+		out:      []byteWithPtrMarshalText{1, 2, 3},
 	},
 	{
-		in:     `["Z01","Z02","Z03"]`,
-		ptr:    new([]byteWithPtrMarshalText),
-		out:    []byteWithPtrMarshalText{1, 2, 3},
-		golden: true,
+		CaseName: Name(""),
+		in:       `["Z01","Z02","Z03"]`,
+		ptr:      new([]byteWithPtrMarshalText),
+		out:      []byteWithPtrMarshalText{1, 2, 3},
+		golden:   true,
 	},
 
 	// ints work with the marshaler but not the base64 []byte case
 	{
-		in:     `["Z01","Z02","Z03"]`,
-		ptr:    new([]intWithMarshalJSON),
-		out:    []intWithMarshalJSON{1, 2, 3},
-		golden: true,
+		CaseName: Name(""),
+		in:       `["Z01","Z02","Z03"]`,
+		ptr:      new([]intWithMarshalJSON),
+		out:      []intWithMarshalJSON{1, 2, 3},
+		golden:   true,
 	},
 	{
-		in:     `["Z01","Z02","Z03"]`,
-		ptr:    new([]intWithMarshalText),
-		out:    []intWithMarshalText{1, 2, 3},
-		golden: true,
+		CaseName: Name(""),
+		in:       `["Z01","Z02","Z03"]`,
+		ptr:      new([]intWithMarshalText),
+		out:      []intWithMarshalText{1, 2, 3},
+		golden:   true,
 	},
 	{
-		in:     `["Z01","Z02","Z03"]`,
-		ptr:    new([]intWithPtrMarshalJSON),
-		out:    []intWithPtrMarshalJSON{1, 2, 3},
-		golden: true,
+		CaseName: Name(""),
+		in:       `["Z01","Z02","Z03"]`,
+		ptr:      new([]intWithPtrMarshalJSON),
+		out:      []intWithPtrMarshalJSON{1, 2, 3},
+		golden:   true,
 	},
 	{
-		in:     `["Z01","Z02","Z03"]`,
-		ptr:    new([]intWithPtrMarshalText),
-		out:    []intWithPtrMarshalText{1, 2, 3},
-		golden: true,
+		CaseName: Name(""),
+		in:       `["Z01","Z02","Z03"]`,
+		ptr:      new([]intWithPtrMarshalText),
+		out:      []intWithPtrMarshalText{1, 2, 3},
+		golden:   true,
 	},
 
-	{in: `0.000001`, ptr: new(float64), out: 0.000001, golden: true},
-	{in: `1e-7`, ptr: new(float64), out: 1e-7, golden: true},
-	{in: `100000000000000000000`, ptr: new(float64), out: 100000000000000000000.0, golden: true},
-	{in: `1e+21`, ptr: new(float64), out: 1e21, golden: true},
-	{in: `-0.000001`, ptr: new(float64), out: -0.000001, golden: true},
-	{in: `-1e-7`, ptr: new(float64), out: -1e-7, golden: true},
-	{in: `-100000000000000000000`, ptr: new(float64), out: -100000000000000000000.0, golden: true},
-	{in: `-1e+21`, ptr: new(float64), out: -1e21, golden: true},
-	{in: `999999999999999900000`, ptr: new(float64), out: 999999999999999900000.0, golden: true},
-	{in: `9007199254740992`, ptr: new(float64), out: 9007199254740992.0, golden: true},
-	{in: `9007199254740993`, ptr: new(float64), out: 9007199254740992.0, golden: false},
+	{CaseName: Name(""), in: `0.000001`, ptr: new(float64), out: 0.000001, golden: true},
+	{CaseName: Name(""), in: `1e-7`, ptr: new(float64), out: 1e-7, golden: true},
+	{CaseName: Name(""), in: `100000000000000000000`, ptr: new(float64), out: 100000000000000000000.0, golden: true},
+	{CaseName: Name(""), in: `1e+21`, ptr: new(float64), out: 1e21, golden: true},
+	{CaseName: Name(""), in: `-0.000001`, ptr: new(float64), out: -0.000001, golden: true},
+	{CaseName: Name(""), in: `-1e-7`, ptr: new(float64), out: -1e-7, golden: true},
+	{CaseName: Name(""), in: `-100000000000000000000`, ptr: new(float64), out: -100000000000000000000.0, golden: true},
+	{CaseName: Name(""), in: `-1e+21`, ptr: new(float64), out: -1e21, golden: true},
+	{CaseName: Name(""), in: `999999999999999900000`, ptr: new(float64), out: 999999999999999900000.0, golden: true},
+	{CaseName: Name(""), in: `9007199254740992`, ptr: new(float64), out: 9007199254740992.0, golden: true},
+	{CaseName: Name(""), in: `9007199254740993`, ptr: new(float64), out: 9007199254740992.0, golden: false},
 
 	{
-		in:  `{"V": {"F2": "hello"}}`,
-		ptr: new(VOuter),
+		CaseName: Name(""),
+		in:       `{"V": {"F2": "hello"}}`,
+		ptr:      new(VOuter),
 		err: &UnmarshalTypeError{
 			Value:  "string",
 			Struct: "V",
 			Field:  "V.F2",
-			Type:   reflect.TypeOf(int32(0)),
+			Type:   reflect.TypeFor[int32](),
 			Offset: 20,
 		},
 	},
 	{
-		in:  `{"V": {"F4": {}, "F2": "hello"}}`,
-		ptr: new(VOuter),
+		CaseName: Name(""),
+		in:       `{"V": {"F4": {}, "F2": "hello"}}`,
+		ptr:      new(VOuter),
 		err: &UnmarshalTypeError{
 			Value:  "string",
 			Struct: "V",
 			Field:  "V.F2",
-			Type:   reflect.TypeOf(int32(0)),
+			Type:   reflect.TypeFor[int32](),
 			Offset: 30,
 		},
 	},
 
 	// issue 15146.
 	// invalid inputs in wrongStringTests below.
-	{in: `{"B":"true"}`, ptr: new(B), out: B{true}, golden: true},
-	{in: `{"B":"false"}`, ptr: new(B), out: B{false}, golden: true},
-	{in: `{"B": "maybe"}`, ptr: new(B), err: errors.New(`json: invalid use of ,string struct tag, trying to unmarshal "maybe" into bool`)},
-	{in: `{"B": "tru"}`, ptr: new(B), err: errors.New(`json: invalid use of ,string struct tag, trying to unmarshal "tru" into bool`)},
-	{in: `{"B": "False"}`, ptr: new(B), err: errors.New(`json: invalid use of ,string struct tag, trying to unmarshal "False" into bool`)},
-	{in: `{"B": "null"}`, ptr: new(B), out: B{false}},
-	{in: `{"B": "nul"}`, ptr: new(B), err: errors.New(`json: invalid use of ,string struct tag, trying to unmarshal "nul" into bool`)},
-	{in: `{"B": [2, 3]}`, ptr: new(B), err: errors.New(`json: invalid use of ,string struct tag, trying to unmarshal unquoted value into bool`)},
+	{CaseName: Name(""), in: `{"B":"true"}`, ptr: new(B), out: B{true}, golden: true},
+	{CaseName: Name(""), in: `{"B":"false"}`, ptr: new(B), out: B{false}, golden: true},
+	{CaseName: Name(""), in: `{"B": "maybe"}`, ptr: new(B), err: errors.New(`json: invalid use of ,string struct tag, trying to unmarshal "maybe" into bool`)},
+	{CaseName: Name(""), in: `{"B": "tru"}`, ptr: new(B), err: errors.New(`json: invalid use of ,string struct tag, trying to unmarshal "tru" into bool`)},
+	{CaseName: Name(""), in: `{"B": "False"}`, ptr: new(B), err: errors.New(`json: invalid use of ,string struct tag, trying to unmarshal "False" into bool`)},
+	{CaseName: Name(""), in: `{"B": "null"}`, ptr: new(B), out: B{false}},
+	{CaseName: Name(""), in: `{"B": "nul"}`, ptr: new(B), err: errors.New(`json: invalid use of ,string struct tag, trying to unmarshal "nul" into bool`)},
+	{CaseName: Name(""), in: `{"B": [2, 3]}`, ptr: new(B), err: errors.New(`json: invalid use of ,string struct tag, trying to unmarshal unquoted value into bool`)},
 
 	// additional tests for disallowUnknownFields
 	{
+		CaseName: Name(""),
 		in: `{
 			"Level0": 1,
 			"Level1b": 2,
@@ -876,6 +922,7 @@ var unmarshalTests = []unmarshalTest{
 		disallowUnknownFields: true,
 	},
 	{
+		CaseName: Name(""),
 		in: `{
 			"Level0": 1,
 			"Level1b": 2,
@@ -899,128 +946,142 @@ var unmarshalTests = []unmarshalTest{
 			"Q": 18
 		}`,
 		ptr:                   new(Top),
-		err:                   fmt.Errorf("json: unknown field \"e.extra\""),
+		err:                   fmt.Errorf("json: unknown field \"extra\""),
 		disallowUnknownFields: true,
 	},
 	// issue 26444
 	// UnmarshalTypeError without field & struct values
 	{
-		in:  `{"data":{"test1": "bob", "test2": 123}}`,
-		ptr: new(mapStringToStringData),
-		err: &UnmarshalTypeError{Value: "number", Type: reflect.TypeOf(""), Offset: 37, Struct: "mapStringToStringData", Field: "data"},
+		CaseName: Name(""),
+		in:       `{"data":{"test1": "bob", "test2": 123}}`,
+		ptr:      new(mapStringToStringData),
+		err:      &UnmarshalTypeError{Value: "number", Type: reflect.TypeFor[string](), Offset: 37, Struct: "mapStringToStringData", Field: "data"},
 	},
 	{
-		in:  `{"data":{"test1": 123, "test2": "bob"}}`,
-		ptr: new(mapStringToStringData),
-		err: &UnmarshalTypeError{Value: "number", Type: reflect.TypeOf(""), Offset: 21, Struct: "mapStringToStringData", Field: "data"},
+		CaseName: Name(""),
+		in:       `{"data":{"test1": 123, "test2": "bob"}}`,
+		ptr:      new(mapStringToStringData),
+		err:      &UnmarshalTypeError{Value: "number", Type: reflect.TypeFor[string](), Offset: 21, Struct: "mapStringToStringData", Field: "data"},
 	},
 
 	// trying to decode JSON arrays or objects via TextUnmarshaler
 	{
-		in:  `[1, 2, 3]`,
-		ptr: new(MustNotUnmarshalText),
-		err: &UnmarshalTypeError{Value: "array", Type: reflect.TypeOf(&MustNotUnmarshalText{}), Offset: 1},
+		CaseName: Name(""),
+		in:       `[1, 2, 3]`,
+		ptr:      new(MustNotUnmarshalText),
+		err:      &UnmarshalTypeError{Value: "array", Type: reflect.TypeFor[*MustNotUnmarshalText](), Offset: 1},
 	},
 	{
-		in:  `{"foo": "bar"}`,
-		ptr: new(MustNotUnmarshalText),
-		err: &UnmarshalTypeError{Value: "object", Type: reflect.TypeOf(&MustNotUnmarshalText{}), Offset: 1},
+		CaseName: Name(""),
+		in:       `{"foo": "bar"}`,
+		ptr:      new(MustNotUnmarshalText),
+		err:      &UnmarshalTypeError{Value: "object", Type: reflect.TypeFor[*MustNotUnmarshalText](), Offset: 1},
 	},
 	// #22369
 	{
-		in:  `{"PP": {"T": {"Y": "bad-type"}}}`,
-		ptr: new(P),
+		CaseName: Name(""),
+		in:       `{"PP": {"T": {"Y": "bad-type"}}}`,
+		ptr:      new(P),
 		err: &UnmarshalTypeError{
 			Value:  "string",
 			Struct: "T",
 			Field:  "PP.T.Y",
-			Type:   reflect.TypeOf(int(0)),
+			Type:   reflect.TypeFor[int](),
 			Offset: 29,
 		},
 	},
 	{
-		in:  `{"Ts": [{"Y": 1}, {"Y": 2}, {"Y": "bad-type"}]}`,
-		ptr: new(PP),
+		CaseName: Name(""),
+		in:       `{"Ts": [{"Y": 1}, {"Y": 2}, {"Y": "bad-type"}]}`,
+		ptr:      new(PP),
 		err: &UnmarshalTypeError{
 			Value:  "string",
 			Struct: "T",
 			Field:  "Ts.Y",
-			Type:   reflect.TypeOf(int(0)),
+			Type:   reflect.TypeFor[int](),
 			Offset: 29,
 		},
 	},
 	// #14702
 	{
-		in:  `invalid`,
-		ptr: new(Number),
+		CaseName: Name(""),
+		in:       `invalid`,
+		ptr:      new(Number),
 		err: &SyntaxError{
 			msg:    "invalid character 'i' looking for beginning of value",
 			Offset: 1,
 		},
 	},
 	{
-		in:  `"invalid"`,
-		ptr: new(Number),
-		err: fmt.Errorf("json: invalid number literal, trying to unmarshal %q into Number", `"invalid"`),
+		CaseName: Name(""),
+		in:       `"invalid"`,
+		ptr:      new(Number),
+		err:      fmt.Errorf("json: invalid number literal, trying to unmarshal %q into Number", `"invalid"`),
 	},
 	{
-		in:  `{"A":"invalid"}`,
-		ptr: new(struct{ A Number }),
-		err: fmt.Errorf("json: invalid number literal, trying to unmarshal %q into Number", `"invalid"`),
+		CaseName: Name(""),
+		in:       `{"A":"invalid"}`,
+		ptr:      new(struct{ A Number }),
+		err:      fmt.Errorf("json: invalid number literal, trying to unmarshal %q into Number", `"invalid"`),
 	},
 	{
-		in: `{"A":"invalid"}`,
+		CaseName: Name(""),
+		in:       `{"A":"invalid"}`,
 		ptr: new(struct {
 			A Number `json:",string"`
 		}),
 		err: fmt.Errorf("json: invalid use of ,string struct tag, trying to unmarshal %q into json.Number", `invalid`),
 	},
 	{
-		in:  `{"A":"invalid"}`,
-		ptr: new(map[string]Number),
-		err: fmt.Errorf("json: invalid number literal, trying to unmarshal %q into Number", `"invalid"`),
+		CaseName: Name(""),
+		in:       `{"A":"invalid"}`,
+		ptr:      new(map[string]Number),
+		err:      fmt.Errorf("json: invalid number literal, trying to unmarshal %q into Number", `"invalid"`),
 	},
 }
 
 func TestMarshal(t *testing.T) {
 	b, err := Marshal(allValue)
 	if err != nil {
-		t.Fatalf("Marshal allValue: %v", err)
+		t.Fatalf("Marshal error: %v", err)
 	}
 	if string(b) != allValueCompact {
-		t.Errorf("Marshal allValueCompact")
+		t.Errorf("Marshal:")
 		diff(t, b, []byte(allValueCompact))
 		return
 	}
 
 	b, err = Marshal(pallValue)
 	if err != nil {
-		t.Fatalf("Marshal pallValue: %v", err)
+		t.Fatalf("Marshal error: %v", err)
 	}
 	if string(b) != pallValueCompact {
-		t.Errorf("Marshal pallValueCompact")
+		t.Errorf("Marshal:")
 		diff(t, b, []byte(pallValueCompact))
 		return
 	}
 }
 
-var badUTF8 = []struct {
-	in, out string
-}{
-	{"hello\xffworld", `"hello\ufffdworld"`},
-	{"", `""`},
-	{"\xff", `"\ufffd"`},
-	{"\xff\xff", `"\ufffd\ufffd"`},
-	{"a\xffb", `"a\ufffdb"`},
-	{"\xe6\x97\xa5\xe6\x9c\xac\xff\xaa\x9e", `"日本\ufffd\ufffd\ufffd"`},
-}
-
-func TestMarshalBadUTF8(t *testing.T) {
-	for _, tt := range badUTF8 {
-		b, err := Marshal(tt.in)
-		if string(b) != tt.out || err != nil {
-			t.Errorf("Marshal(%q) = %#q, %v, want %#q, nil", tt.in, b, err, tt.out)
-		}
+func TestMarshalInvalidUTF8(t *testing.T) {
+	tests := []struct {
+		CaseName
+		in   string
+		want string
+	}{
+		{Name(""), "hello\xffworld", `"hello\ufffdworld"`},
+		{Name(""), "", `""`},
+		{Name(""), "\xff", `"\ufffd"`},
+		{Name(""), "\xff\xff", `"\ufffd\ufffd"`},
+		{Name(""), "a\xffb", `"a\ufffdb"`},
+		{Name(""), "\xe6\x97\xa5\xe6\x9c\xac\xff\xaa\x9e", `"日本\ufffd\ufffd\ufffd"`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.Name, func(t *testing.T) {
+			got, err := Marshal(tt.in)
+			if string(got) != tt.want || err != nil {
+				t.Errorf("%s: Marshal(%q):\n\tgot:  (%q, %v)\n\twant: (%q, nil)", tt.Where, tt.in, got, err, tt.want)
+			}
+		})
 	}
 }
 
@@ -1028,11 +1089,11 @@ func TestMarshalNumberZeroVal(t *testing.T) {
 	var n Number
 	out, err := Marshal(n)
 	if err != nil {
-		t.Fatal(err)
+		t.Fatalf("Marshal error: %v", err)
 	}
-	outStr := string(out)
-	if outStr != "0" {
-		t.Fatalf("Invalid zero val for Number: %q", outStr)
+	got := string(out)
+	if got != "0" {
+		t.Fatalf("Marshal: got %s, want 0", got)
 	}
 }
 
@@ -1068,109 +1129,98 @@ func TestMarshalEmbeds(t *testing.T) {
 			Q: 18,
 		},
 	}
-	b, err := Marshal(top)
+	got, err := Marshal(top)
 	if err != nil {
-		t.Fatal(err)
+		t.Fatalf("Marshal error: %v", err)
 	}
 	want := "{\"Level0\":1,\"Level1b\":2,\"Level1c\":3,\"Level1a\":5,\"LEVEL1B\":6,\"e\":{\"Level1a\":8,\"Level1b\":9,\"Level1c\":10,\"Level1d\":11,\"x\":12},\"Loop1\":13,\"Loop2\":14,\"X\":15,\"Y\":16,\"Z\":17,\"Q\":18}"
-	if string(b) != want {
-		t.Errorf("Wrong marshal result.\n got: %q\nwant: %q", b, want)
+	if string(got) != want {
+		t.Errorf("Marshal:\n\tgot:  %s\n\twant: %s", got, want)
 	}
 }
 
 func equalError(a, b error) bool {
-	if a == nil {
-		return b == nil
-	}
-	if b == nil {
-		return a == nil
+	if a == nil || b == nil {
+		return a == nil && b == nil
 	}
 	return a.Error() == b.Error()
 }
 
 func TestUnmarshal(t *testing.T) {
-	for i, tt := range unmarshalTests {
-		var scan scanner
-		in := []byte(tt.in)
-		if err := checkValid(in, &scan); err != nil {
-			if !equalError(err, tt.err) {
-				t.Errorf("#%d: checkValid: %#v", i, err)
-				continue
+	for _, tt := range unmarshalTests {
+		t.Run(tt.Name, func(t *testing.T) {
+			in := []byte(tt.in)
+			var scan scanner
+			if err := checkValid(in, &scan); err != nil {
+				if !equalError(err, tt.err) {
+					t.Fatalf("%s: checkValid error: %#v", tt.Where, err)
+				}
 			}
-		}
-		if tt.ptr == nil {
-			continue
-		}
-
-		typ := reflect.TypeOf(tt.ptr)
-		if typ.Kind() != reflect.Pointer {
-			t.Errorf("#%d: unmarshalTest.ptr %T is not a pointer type", i, tt.ptr)
-			continue
-		}
-		typ = typ.Elem()
-
-		// v = new(right-type)
-		v := reflect.New(typ)
-
-		if !reflect.DeepEqual(tt.ptr, v.Interface()) {
-			// There's no reason for ptr to point to non-zero data,
-			// as we decode into new(right-type), so the data is
-			// discarded.
-			// This can easily mean tests that silently don't test
-			// what they should. To test decoding into existing
-			// data, see TestPrefilled.
-			t.Errorf("#%d: unmarshalTest.ptr %#v is not a pointer to a zero value", i, tt.ptr)
-			continue
-		}
-
-		dec := NewDecoder(bytes.NewReader(in))
-		if tt.useNumber {
-			dec.UseNumber()
-		}
-		if tt.disallowUnknownFields {
-			dec.DisallowUnknownFields()
-		}
-		if err := dec.Decode(v.Interface()); !equalError(err, tt.err) {
-			t.Errorf("#%d: %v, want %v", i, err, tt.err)
-			continue
-		} else if err != nil {
-			continue
-		}
-		if !reflect.DeepEqual(v.Elem().Interface(), tt.out) {
-			t.Errorf("#%d: mismatch\nhave: %#+v\nwant: %#+v", i, v.Elem().Interface(), tt.out)
-			data, _ := Marshal(v.Elem().Interface())
-			println(string(data))
-			data, _ = Marshal(tt.out)
-			println(string(data))
-			continue
-		}
-
-		// Check round trip also decodes correctly.
-		if tt.err == nil {
-			enc, err := Marshal(v.Interface())
-			if err != nil {
-				t.Errorf("#%d: error re-marshaling: %v", i, err)
-				continue
+			if tt.ptr == nil {
+				return
 			}
-			if tt.golden && !bytes.Equal(enc, in) {
-				t.Errorf("#%d: remarshal mismatch:\nhave: %s\nwant: %s", i, enc, in)
+
+			typ := reflect.TypeOf(tt.ptr)
+			if typ.Kind() != reflect.Pointer {
+				t.Fatalf("%s: unmarshalTest.ptr %T is not a pointer type", tt.Where, tt.ptr)
 			}
-			vv := reflect.New(reflect.TypeOf(tt.ptr).Elem())
-			dec = NewDecoder(bytes.NewReader(enc))
+			typ = typ.Elem()
+
+			// v = new(right-type)
+			v := reflect.New(typ)
+
+			if !reflect.DeepEqual(tt.ptr, v.Interface()) {
+				// There's no reason for ptr to point to non-zero data,
+				// as we decode into new(right-type), so the data is
+				// discarded.
+				// This can easily mean tests that silently don't test
+				// what they should. To test decoding into existing
+				// data, see TestPrefilled.
+				t.Fatalf("%s: unmarshalTest.ptr %#v is not a pointer to a zero value", tt.Where, tt.ptr)
+			}
+
+			dec := NewDecoder(bytes.NewReader(in))
 			if tt.useNumber {
 				dec.UseNumber()
 			}
-			if err := dec.Decode(vv.Interface()); err != nil {
-				t.Errorf("#%d: error re-unmarshaling %#q: %v", i, enc, err)
-				continue
+			if tt.disallowUnknownFields {
+				dec.DisallowUnknownFields()
 			}
-			if !reflect.DeepEqual(v.Elem().Interface(), vv.Elem().Interface()) {
-				t.Errorf("#%d: mismatch\nhave: %#+v\nwant: %#+v", i, v.Elem().Interface(), vv.Elem().Interface())
-				t.Errorf("     In: %q", strings.Map(noSpace, string(in)))
-				t.Errorf("Marshal: %q", strings.Map(noSpace, string(enc)))
-				continue
+			if err := dec.Decode(v.Interface()); !equalError(err, tt.err) {
+				t.Fatalf("%s: Decode error:\n\tgot:  %v\n\twant: %v", tt.Where, err, tt.err)
+			} else if err != nil {
+				return
 			}
-		}
+			if got := v.Elem().Interface(); !reflect.DeepEqual(got, tt.out) {
+				gotJSON, _ := Marshal(got)
+				wantJSON, _ := Marshal(tt.out)
+				t.Fatalf("%s: Decode:\n\tgot:  %#+v\n\twant: %#+v\n\n\tgotJSON:  %s\n\twantJSON: %s", tt.Where, got, tt.out, gotJSON, wantJSON)
+			}
+
+			// Check round trip also decodes correctly.
+			if tt.err == nil {
+				enc, err := Marshal(v.Interface())
+				if err != nil {
+					t.Fatalf("%s: Marshal error after roundtrip: %v", tt.Where, err)
+				}
+				if tt.golden && !bytes.Equal(enc, in) {
+					t.Errorf("%s: Marshal:\n\tgot:  %s\n\twant: %s", tt.Where, enc, in)
+				}
+				vv := reflect.New(reflect.TypeOf(tt.ptr).Elem())
+				dec = NewDecoder(bytes.NewReader(enc))
+				if tt.useNumber {
+					dec.UseNumber()
+				}
+				if err := dec.Decode(vv.Interface()); err != nil {
+					t.Fatalf("%s: Decode(%#q) error after roundtrip: %v", tt.Where, enc, err)
+				}
+				if !reflect.DeepEqual(v.Elem().Interface(), vv.Elem().Interface()) {
+					t.Fatalf("%s: Decode:\n\tgot:  %#+v\n\twant: %#+v\n\n\tgotJSON:  %s\n\twantJSON: %s",
+						tt.Where, v.Elem().Interface(), vv.Elem().Interface(),
+						stripWhitespace(string(enc)), stripWhitespace(string(in)))
+				}
+			}
+		})
 	}
 }
 
@@ -1178,48 +1228,50 @@ func TestUnmarshalMarshal(t *testing.T) {
 	initBig()
 	var v any
 	if err := Unmarshal(jsonBig, &v); err != nil {
-		t.Fatalf("Unmarshal: %v", err)
+		t.Fatalf("Unmarshal error: %v", err)
 	}
 	b, err := Marshal(v)
 	if err != nil {
-		t.Fatalf("Marshal: %v", err)
+		t.Fatalf("Marshal error: %v", err)
 	}
 	if !bytes.Equal(jsonBig, b) {
-		t.Errorf("Marshal jsonBig")
+		t.Errorf("Marshal:")
 		diff(t, b, jsonBig)
 		return
 	}
 }
 
-var numberTests = []struct {
-	in       string
-	i        int64
-	intErr   string
-	f        float64
-	floatErr string
-}{
-	{in: "-1.23e1", intErr: "strconv.ParseInt: parsing \"-1.23e1\": invalid syntax", f: -1.23e1},
-	{in: "-12", i: -12, f: -12.0},
-	{in: "1e1000", intErr: "strconv.ParseInt: parsing \"1e1000\": invalid syntax", floatErr: "strconv.ParseFloat: parsing \"1e1000\": value out of range"},
-}
-
 // Independent of Decode, basic coverage of the accessors in Number
 func TestNumberAccessors(t *testing.T) {
-	for _, tt := range numberTests {
-		n := Number(tt.in)
-		if s := n.String(); s != tt.in {
-			t.Errorf("Number(%q).String() is %q", tt.in, s)
-		}
-		if i, err := n.Int64(); err == nil && tt.intErr == "" && i != tt.i {
-			t.Errorf("Number(%q).Int64() is %d", tt.in, i)
-		} else if (err == nil && tt.intErr != "") || (err != nil && err.Error() != tt.intErr) {
-			t.Errorf("Number(%q).Int64() wanted error %q but got: %v", tt.in, tt.intErr, err)
-		}
-		if f, err := n.Float64(); err == nil && tt.floatErr == "" && f != tt.f {
-			t.Errorf("Number(%q).Float64() is %g", tt.in, f)
-		} else if (err == nil && tt.floatErr != "") || (err != nil && err.Error() != tt.floatErr) {
-			t.Errorf("Number(%q).Float64() wanted error %q but got: %v", tt.in, tt.floatErr, err)
-		}
+	tests := []struct {
+		CaseName
+		in       string
+		i        int64
+		intErr   string
+		f        float64
+		floatErr string
+	}{
+		{CaseName: Name(""), in: "-1.23e1", intErr: "strconv.ParseInt: parsing \"-1.23e1\": invalid syntax", f: -1.23e1},
+		{CaseName: Name(""), in: "-12", i: -12, f: -12.0},
+		{CaseName: Name(""), in: "1e1000", intErr: "strconv.ParseInt: parsing \"1e1000\": invalid syntax", floatErr: "strconv.ParseFloat: parsing \"1e1000\": value out of range"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.Name, func(t *testing.T) {
+			n := Number(tt.in)
+			if got := n.String(); got != tt.in {
+				t.Errorf("%s: Number(%q).String() = %s, want %s", tt.Where, tt.in, got, tt.in)
+			}
+			if i, err := n.Int64(); err == nil && tt.intErr == "" && i != tt.i {
+				t.Errorf("%s: Number(%q).Int64() = %d, want %d", tt.Where, tt.in, i, tt.i)
+			} else if (err == nil && tt.intErr != "") || (err != nil && err.Error() != tt.intErr) {
+				t.Errorf("%s: Number(%q).Int64() error:\n\tgot:  %v\n\twant: %v", tt.Where, tt.in, err, tt.intErr)
+			}
+			if f, err := n.Float64(); err == nil && tt.floatErr == "" && f != tt.f {
+				t.Errorf("%s: Number(%q).Float64() = %g, want %g", tt.Where, tt.in, f, tt.f)
+			} else if (err == nil && tt.floatErr != "") || (err != nil && err.Error() != tt.floatErr) {
+				t.Errorf("%s: Number(%q).Float64() error:\n\tgot  %v\n\twant: %v", tt.Where, tt.in, err, tt.floatErr)
+			}
+		})
 	}
 }
 
@@ -1230,14 +1282,14 @@ func TestLargeByteSlice(t *testing.T) {
 	}
 	b, err := Marshal(s0)
 	if err != nil {
-		t.Fatalf("Marshal: %v", err)
+		t.Fatalf("Marshal error: %v", err)
 	}
 	var s1 []byte
 	if err := Unmarshal(b, &s1); err != nil {
-		t.Fatalf("Unmarshal: %v", err)
+		t.Fatalf("Unmarshal error: %v", err)
 	}
 	if !bytes.Equal(s0, s1) {
-		t.Errorf("Marshal large byte slice")
+		t.Errorf("Marshal:")
 		diff(t, s0, s1)
 	}
 }
@@ -1250,10 +1302,10 @@ func TestUnmarshalInterface(t *testing.T) {
 	var xint Xint
 	var i any = &xint
 	if err := Unmarshal([]byte(`{"X":1}`), &i); err != nil {
-		t.Fatalf("Unmarshal: %v", err)
+		t.Fatalf("Unmarshal error: %v", err)
 	}
 	if xint.X != 1 {
-		t.Fatalf("Did not write to xint")
+		t.Fatalf("xint.X = %d, want 1", xint.X)
 	}
 }
 
@@ -1264,59 +1316,51 @@ func TestUnmarshalPtrPtr(t *testing.T) {
 		t.Fatalf("Unmarshal: %v", err)
 	}
 	if xint.X != 1 {
-		t.Fatalf("Did not write to xint")
+		t.Fatalf("xint.X = %d, want 1", xint.X)
 	}
 }
 
 func TestEscape(t *testing.T) {
 	const input = `"foobar"<html>` + " [\u2028 \u2029]"
-	const expected = `"\"foobar\"\u003chtml\u003e [\u2028 \u2029]"`
-	b, err := Marshal(input)
+	const want = `"\"foobar\"\u003chtml\u003e [\u2028 \u2029]"`
+	got, err := Marshal(input)
 	if err != nil {
 		t.Fatalf("Marshal error: %v", err)
 	}
-	if s := string(b); s != expected {
-		t.Errorf("Encoding of [%s]:\n got [%s]\nwant [%s]", input, s, expected)
+	if string(got) != want {
+		t.Errorf("Marshal(%#q):\n\tgot:  %s\n\twant: %s", input, got, want)
 	}
-}
-
-// WrongString is a struct that's misusing the ,string modifier.
-type WrongString struct {
-	Message string `json:"result,string"`
-}
-
-type wrongStringTest struct {
-	in, err string
-}
-
-var wrongStringTests = []wrongStringTest{
-	{`{"result":"x"}`, `json: invalid use of ,string struct tag, trying to unmarshal "x" into string`},
-	{`{"result":"foo"}`, `json: invalid use of ,string struct tag, trying to unmarshal "foo" into string`},
-	{`{"result":"123"}`, `json: invalid use of ,string struct tag, trying to unmarshal "123" into string`},
-	{`{"result":123}`, `json: invalid use of ,string struct tag, trying to unmarshal unquoted value into string`},
-	{`{"result":"\""}`, `json: invalid use of ,string struct tag, trying to unmarshal "\"" into string`},
-	{`{"result":"\"foo"}`, `json: invalid use of ,string struct tag, trying to unmarshal "\"foo" into string`},
 }
 
 // If people misuse the ,string modifier, the error message should be
 // helpful, telling the user that they're doing it wrong.
 func TestErrorMessageFromMisusedString(t *testing.T) {
-	for n, tt := range wrongStringTests {
-		r := strings.NewReader(tt.in)
-		var s WrongString
-		err := NewDecoder(r).Decode(&s)
-		got := fmt.Sprintf("%v", err)
-		if got != tt.err {
-			t.Errorf("%d. got err = %q, want %q", n, got, tt.err)
-		}
+	// WrongString is a struct that's misusing the ,string modifier.
+	type WrongString struct {
+		Message string `json:"result,string"`
 	}
-}
-
-func noSpace(c rune) rune {
-	if isSpace(byte(c)) { //only used for ascii
-		return -1
+	tests := []struct {
+		CaseName
+		in, err string
+	}{
+		{Name(""), `{"result":"x"}`, `json: invalid use of ,string struct tag, trying to unmarshal "x" into string`},
+		{Name(""), `{"result":"foo"}`, `json: invalid use of ,string struct tag, trying to unmarshal "foo" into string`},
+		{Name(""), `{"result":"123"}`, `json: invalid use of ,string struct tag, trying to unmarshal "123" into string`},
+		{Name(""), `{"result":123}`, `json: invalid use of ,string struct tag, trying to unmarshal unquoted value into string`},
+		{Name(""), `{"result":"\""}`, `json: invalid use of ,string struct tag, trying to unmarshal "\"" into string`},
+		{Name(""), `{"result":"\"foo"}`, `json: invalid use of ,string struct tag, trying to unmarshal "\"foo" into string`},
 	}
-	return c
+	for _, tt := range tests {
+		t.Run(tt.Name, func(t *testing.T) {
+			r := strings.NewReader(tt.in)
+			var s WrongString
+			err := NewDecoder(r).Decode(&s)
+			got := fmt.Sprintf("%v", err)
+			if got != tt.err {
+				t.Errorf("%s: Decode error:\n\tgot:  %s\n\twant: %s", tt.Where, got, tt.err)
+			}
+		})
+	}
 }
 
 type All struct {
@@ -1546,7 +1590,7 @@ var allValueIndent = `{
 	"PInterface": null
 }`
 
-var allValueCompact = strings.Map(noSpace, allValueIndent)
+var allValueCompact = stripWhitespace(allValueIndent)
 
 var pallValueIndent = `{
 	"Bool": false,
@@ -1635,7 +1679,7 @@ var pallValueIndent = `{
 	"PInterface": 5.2
 }`
 
-var pallValueCompact = strings.Map(noSpace, pallValueIndent)
+var pallValueCompact = stripWhitespace(pallValueIndent)
 
 func TestRefUnmarshal(t *testing.T) {
 	type S struct {
@@ -1656,10 +1700,10 @@ func TestRefUnmarshal(t *testing.T) {
 
 	var got S
 	if err := Unmarshal([]byte(`{"R0":"ref","R1":"ref","R2":"ref","R3":"ref"}`), &got); err != nil {
-		t.Fatalf("Unmarshal: %v", err)
+		t.Fatalf("Unmarshal error: %v", err)
 	}
 	if !reflect.DeepEqual(got, want) {
-		t.Errorf("got %+v, want %+v", got, want)
+		t.Errorf("Unmarsha:\n\tgot:  %+v\n\twant: %+v", got, want)
 	}
 }
 
@@ -1672,13 +1716,12 @@ func TestEmptyString(t *testing.T) {
 	}
 	data := `{"Number1":"1", "Number2":""}`
 	dec := NewDecoder(strings.NewReader(data))
-	var t2 T2
-	err := dec.Decode(&t2)
-	if err == nil {
-		t.Fatal("Decode: did not return error")
-	}
-	if t2.Number1 != 1 {
-		t.Fatal("Decode: did not set Number1")
+	var got T2
+	switch err := dec.Decode(&got); {
+	case err == nil:
+		t.Fatalf("Decode error: got nil, want non-nil")
+	case got.Number1 != 1:
+		t.Fatalf("Decode: got.Number1 = %d, want 1", got.Number1)
 	}
 }
 
@@ -1695,12 +1738,13 @@ func TestNullString(t *testing.T) {
 	s.B = 1
 	s.C = new(int)
 	*s.C = 2
-	err := Unmarshal(data, &s)
-	if err != nil {
-		t.Fatalf("Unmarshal: %v", err)
-	}
-	if s.B != 1 || s.C != nil {
-		t.Fatalf("after Unmarshal, s.B=%d, s.C=%p, want 1, nil", s.B, s.C)
+	switch err := Unmarshal(data, &s); {
+	case err != nil:
+		t.Fatalf("Unmarshal error: %v", err)
+	case s.B != 1:
+		t.Fatalf("Unmarshal: s.B = %d, want 1", s.B)
+	case s.C != nil:
+		t.Fatalf("Unmarshal: s.C = %d, want non-nil", s.C)
 	}
 }
 
@@ -1716,37 +1760,38 @@ func intpp(x *int) **int {
 	return pp
 }
 
-var interfaceSetTests = []struct {
-	pre  any
-	json string
-	post any
-}{
-	{"foo", `"bar"`, "bar"},
-	{"foo", `2`, 2.0},
-	{"foo", `true`, true},
-	{"foo", `null`, nil},
-
-	{nil, `null`, nil},
-	{new(int), `null`, nil},
-	{(*int)(nil), `null`, nil},
-	{new(*int), `null`, new(*int)},
-	{(**int)(nil), `null`, nil},
-	{intp(1), `null`, nil},
-	{intpp(nil), `null`, intpp(nil)},
-	{intpp(intp(1)), `null`, intpp(nil)},
-}
-
 func TestInterfaceSet(t *testing.T) {
-	for _, tt := range interfaceSetTests {
-		b := struct{ X any }{tt.pre}
-		blob := `{"X":` + tt.json + `}`
-		if err := Unmarshal([]byte(blob), &b); err != nil {
-			t.Errorf("Unmarshal %#q: %v", blob, err)
-			continue
-		}
-		if !reflect.DeepEqual(b.X, tt.post) {
-			t.Errorf("Unmarshal %#q into %#v: X=%#v, want %#v", blob, tt.pre, b.X, tt.post)
-		}
+	tests := []struct {
+		CaseName
+		pre  any
+		json string
+		post any
+	}{
+		{Name(""), "foo", `"bar"`, "bar"},
+		{Name(""), "foo", `2`, 2.0},
+		{Name(""), "foo", `true`, true},
+		{Name(""), "foo", `null`, nil},
+
+		{Name(""), nil, `null`, nil},
+		{Name(""), new(int), `null`, nil},
+		{Name(""), (*int)(nil), `null`, nil},
+		{Name(""), new(*int), `null`, new(*int)},
+		{Name(""), (**int)(nil), `null`, nil},
+		{Name(""), intp(1), `null`, nil},
+		{Name(""), intpp(nil), `null`, intpp(nil)},
+		{Name(""), intpp(intp(1)), `null`, intpp(nil)},
+	}
+	for _, tt := range tests {
+		t.Run(tt.Name, func(t *testing.T) {
+			b := struct{ X any }{tt.pre}
+			blob := `{"X":` + tt.json + `}`
+			if err := Unmarshal([]byte(blob), &b); err != nil {
+				t.Fatalf("%s: Unmarshal(%#q) error: %v", tt.Where, blob, err)
+			}
+			if !reflect.DeepEqual(b.X, tt.post) {
+				t.Errorf("%s: Unmarshal(%#q):\n\tpre.X:  %#v\n\tgot.X:  %#v\n\twant.X: %#v", tt.Where, blob, tt.pre, b.X, tt.post)
+			}
+		})
 	}
 }
 
@@ -1924,24 +1969,18 @@ func (x MustNotUnmarshalText) UnmarshalText(text []byte) error {
 
 func TestStringKind(t *testing.T) {
 	type stringKind string
-
-	var m1, m2 map[stringKind]int
-	m1 = map[stringKind]int{
-		"foo": 42,
-	}
-
-	data, err := Marshal(m1)
+	want := map[stringKind]int{"foo": 42}
+	data, err := Marshal(want)
 	if err != nil {
-		t.Errorf("Unexpected error marshaling: %v", err)
+		t.Fatalf("Marshal error: %v", err)
 	}
-
-	err = Unmarshal(data, &m2)
+	var got map[stringKind]int
+	err = Unmarshal(data, &got)
 	if err != nil {
-		t.Errorf("Unexpected error unmarshaling: %v", err)
+		t.Fatalf("Unmarshal error: %v", err)
 	}
-
-	if !reflect.DeepEqual(m1, m2) {
-		t.Error("Items should be equal after encoding and then decoding")
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("Marshal/Unmarshal mismatch:\n\tgot:  %v\n\twant: %v", got, want)
 	}
 }
 
@@ -1950,20 +1989,18 @@ func TestStringKind(t *testing.T) {
 // Issue 8962.
 func TestByteKind(t *testing.T) {
 	type byteKind []byte
-
-	a := byteKind("hello")
-
-	data, err := Marshal(a)
+	want := byteKind("hello")
+	data, err := Marshal(want)
 	if err != nil {
-		t.Error(err)
+		t.Fatalf("Marshal error: %v", err)
 	}
-	var b byteKind
-	err = Unmarshal(data, &b)
+	var got byteKind
+	err = Unmarshal(data, &got)
 	if err != nil {
-		t.Fatal(err)
+		t.Fatalf("Unmarshal error: %v", err)
 	}
-	if !reflect.DeepEqual(a, b) {
-		t.Errorf("expected %v == %v", a, b)
+	if !slices.Equal(got, want) {
+		t.Fatalf("Marshal/Unmarshal mismatch:\n\tgot:  %v\n\twant: %v", got, want)
 	}
 }
 
@@ -1971,63 +2008,68 @@ func TestByteKind(t *testing.T) {
 // Issue 12921.
 func TestSliceOfCustomByte(t *testing.T) {
 	type Uint8 uint8
-
-	a := []Uint8("hello")
-
-	data, err := Marshal(a)
+	want := []Uint8("hello")
+	data, err := Marshal(want)
 	if err != nil {
-		t.Fatal(err)
+		t.Fatalf("Marshal error: %v", err)
 	}
-	var b []Uint8
-	err = Unmarshal(data, &b)
+	var got []Uint8
+	err = Unmarshal(data, &got)
 	if err != nil {
-		t.Fatal(err)
+		t.Fatalf("Unmarshal error: %v", err)
 	}
-	if !reflect.DeepEqual(a, b) {
-		t.Fatalf("expected %v == %v", a, b)
+	if !slices.Equal(got, want) {
+		t.Fatalf("Marshal/Unmarshal mismatch:\n\tgot:  %v\n\twant: %v", got, want)
 	}
-}
-
-var decodeTypeErrorTests = []struct {
-	dest any
-	src  string
-}{
-	{new(string), `{"user": "name"}`}, // issue 4628.
-	{new(error), `{}`},                // issue 4222
-	{new(error), `[]`},
-	{new(error), `""`},
-	{new(error), `123`},
-	{new(error), `true`},
 }
 
 func TestUnmarshalTypeError(t *testing.T) {
-	for _, item := range decodeTypeErrorTests {
-		err := Unmarshal([]byte(item.src), item.dest)
-		if _, ok := err.(*UnmarshalTypeError); !ok {
-			t.Errorf("expected type error for Unmarshal(%q, type %T): got %T",
-				item.src, item.dest, err)
-		}
+	tests := []struct {
+		CaseName
+		dest any
+		in   string
+	}{
+		{Name(""), new(string), `{"user": "name"}`}, // issue 4628.
+		{Name(""), new(error), `{}`},                // issue 4222
+		{Name(""), new(error), `[]`},
+		{Name(""), new(error), `""`},
+		{Name(""), new(error), `123`},
+		{Name(""), new(error), `true`},
 	}
-}
-
-var unmarshalSyntaxTests = []string{
-	"tru",
-	"fals",
-	"nul",
-	"123e",
-	`"hello`,
-	`[1,2,3`,
-	`{"key":1`,
-	`{"key":1,`,
+	for _, tt := range tests {
+		t.Run(tt.Name, func(t *testing.T) {
+			err := Unmarshal([]byte(tt.in), tt.dest)
+			if _, ok := err.(*UnmarshalTypeError); !ok {
+				t.Errorf("%s: Unmarshal(%#q, %T):\n\tgot:  %T\n\twant: %T",
+					tt.Where, tt.in, tt.dest, err, new(UnmarshalTypeError))
+			}
+		})
+	}
 }
 
 func TestUnmarshalSyntax(t *testing.T) {
 	var x any
-	for _, src := range unmarshalSyntaxTests {
-		err := Unmarshal([]byte(src), &x)
-		if _, ok := err.(*SyntaxError); !ok {
-			t.Errorf("expected syntax error for Unmarshal(%q): got %T", src, err)
-		}
+	tests := []struct {
+		CaseName
+		in string
+	}{
+		{Name(""), "tru"},
+		{Name(""), "fals"},
+		{Name(""), "nul"},
+		{Name(""), "123e"},
+		{Name(""), `"hello`},
+		{Name(""), `[1,2,3`},
+		{Name(""), `{"key":1`},
+		{Name(""), `{"key":1,`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.Name, func(t *testing.T) {
+			err := Unmarshal([]byte(tt.in), &x)
+			if _, ok := err.(*SyntaxError); !ok {
+				t.Errorf("%s: Unmarshal(%#q, any):\n\tgot:  %T\n\twant: %T",
+					tt.Where, tt.in, err, new(SyntaxError))
+			}
+		})
 	}
 }
 
@@ -2048,10 +2090,10 @@ func TestUnmarshalUnexported(t *testing.T) {
 	out := &unexportedFields{}
 	err := Unmarshal([]byte(input), out)
 	if err != nil {
-		t.Errorf("got error %v, expected nil", err)
+		t.Errorf("Unmarshal error: %v", err)
 	}
 	if !reflect.DeepEqual(out, want) {
-		t.Errorf("got %q, want %q", out, want)
+		t.Errorf("Unmarshal:\n\tgot:  %+v\n\twant: %+v", out, want)
 	}
 }
 
@@ -2073,12 +2115,11 @@ func (t *Time3339) UnmarshalJSON(b []byte) error {
 
 func TestUnmarshalJSONLiteralError(t *testing.T) {
 	var t3 Time3339
-	err := Unmarshal([]byte(`"0000-00-00T00:00:00Z"`), &t3)
-	if err == nil {
-		t.Fatalf("expected error; got time %v", time.Time(t3))
-	}
-	if !strings.Contains(err.Error(), "range") {
-		t.Errorf("got err = %v; want out of range error", err)
+	switch err := Unmarshal([]byte(`"0000-00-00T00:00:00Z"`), &t3); {
+	case err == nil:
+		t.Fatalf("Unmarshal error: got nil, want non-nil")
+	case !strings.Contains(err.Error(), "range"):
+		t.Errorf("Unmarshal error:\n\tgot:  %v\n\twant: out of range", err)
 	}
 }
 
@@ -2091,7 +2132,7 @@ func TestSkipArrayObjects(t *testing.T) {
 
 	err := Unmarshal([]byte(json), &dest)
 	if err != nil {
-		t.Errorf("got error %q, want nil", err)
+		t.Errorf("Unmarshal error: %v", err)
 	}
 }
 
@@ -2100,99 +2141,102 @@ func TestSkipArrayObjects(t *testing.T) {
 // Issues 4900 and 8837, among others.
 func TestPrefilled(t *testing.T) {
 	// Values here change, cannot reuse table across runs.
-	var prefillTests = []struct {
+	tests := []struct {
+		CaseName
 		in  string
 		ptr any
 		out any
-	}{
-		{
-			in:  `{"X": 1, "Y": 2}`,
-			ptr: &XYZ{X: float32(3), Y: int16(4), Z: 1.5},
-			out: &XYZ{X: float64(1), Y: float64(2), Z: 1.5},
-		},
-		{
-			in:  `{"X": 1, "Y": 2}`,
-			ptr: &map[string]any{"X": float32(3), "Y": int16(4), "Z": 1.5},
-			out: &map[string]any{"X": float64(1), "Y": float64(2), "Z": 1.5},
-		},
-		{
-			in:  `[2]`,
-			ptr: &[]int{1},
-			out: &[]int{2},
-		},
-		{
-			in:  `[2, 3]`,
-			ptr: &[]int{1},
-			out: &[]int{2, 3},
-		},
-		{
-			in:  `[2, 3]`,
-			ptr: &[...]int{1},
-			out: &[...]int{2},
-		},
-		{
-			in:  `[3]`,
-			ptr: &[...]int{1, 2},
-			out: &[...]int{3, 0},
-		},
+	}{{
+		CaseName: Name(""),
+		in:       `{"X": 1, "Y": 2}`,
+		ptr:      &XYZ{X: float32(3), Y: int16(4), Z: 1.5},
+		out:      &XYZ{X: float64(1), Y: float64(2), Z: 1.5},
+	}, {
+		CaseName: Name(""),
+		in:       `{"X": 1, "Y": 2}`,
+		ptr:      &map[string]any{"X": float32(3), "Y": int16(4), "Z": 1.5},
+		out:      &map[string]any{"X": float64(1), "Y": float64(2), "Z": 1.5},
+	}, {
+		CaseName: Name(""),
+		in:       `[2]`,
+		ptr:      &[]int{1},
+		out:      &[]int{2},
+	}, {
+		CaseName: Name(""),
+		in:       `[2, 3]`,
+		ptr:      &[]int{1},
+		out:      &[]int{2, 3},
+	}, {
+		CaseName: Name(""),
+		in:       `[2, 3]`,
+		ptr:      &[...]int{1},
+		out:      &[...]int{2},
+	}, {
+		CaseName: Name(""),
+		in:       `[3]`,
+		ptr:      &[...]int{1, 2},
+		out:      &[...]int{3, 0},
+	}}
+	for _, tt := range tests {
+		t.Run(tt.Name, func(t *testing.T) {
+			ptrstr := fmt.Sprintf("%v", tt.ptr)
+			err := Unmarshal([]byte(tt.in), tt.ptr) // tt.ptr edited here
+			if err != nil {
+				t.Errorf("%s: Unmarshal error: %v", tt.Where, err)
+			}
+			if !reflect.DeepEqual(tt.ptr, tt.out) {
+				t.Errorf("%s: Unmarshal(%#q, %T):\n\tgot:  %v\n\twant: %v", tt.Where, tt.in, ptrstr, tt.ptr, tt.out)
+			}
+		})
 	}
-
-	for _, tt := range prefillTests {
-		ptrstr := fmt.Sprintf("%v", tt.ptr)
-		err := Unmarshal([]byte(tt.in), tt.ptr) // tt.ptr edited here
-		if err != nil {
-			t.Errorf("Unmarshal: %v", err)
-		}
-		if !reflect.DeepEqual(tt.ptr, tt.out) {
-			t.Errorf("Unmarshal(%#q, %s): have %v, want %v", tt.in, ptrstr, tt.ptr, tt.out)
-		}
-	}
-}
-
-var invalidUnmarshalTests = []struct {
-	v    any
-	want string
-}{
-	{nil, "json: Unmarshal(nil)"},
-	{struct{}{}, "json: Unmarshal(non-pointer struct {})"},
-	{(*int)(nil), "json: Unmarshal(nil *int)"},
 }
 
 func TestInvalidUnmarshal(t *testing.T) {
 	buf := []byte(`{"a":"1"}`)
-	for _, tt := range invalidUnmarshalTests {
-		err := Unmarshal(buf, tt.v)
-		if err == nil {
-			t.Errorf("Unmarshal expecting error, got nil")
-			continue
-		}
-		if got := err.Error(); got != tt.want {
-			t.Errorf("Unmarshal = %q; want %q", got, tt.want)
-		}
+	tests := []struct {
+		CaseName
+		v    any
+		want string
+	}{
+		{Name(""), nil, "json: Unmarshal(nil)"},
+		{Name(""), struct{}{}, "json: Unmarshal(non-pointer struct {})"},
+		{Name(""), (*int)(nil), "json: Unmarshal(nil *int)"},
 	}
-}
-
-var invalidUnmarshalTextTests = []struct {
-	v    any
-	want string
-}{
-	{nil, "json: Unmarshal(nil)"},
-	{struct{}{}, "json: Unmarshal(non-pointer struct {})"},
-	{(*int)(nil), "json: Unmarshal(nil *int)"},
-	{new(net.IP), "json: cannot unmarshal number into Go value of type *net.IP"},
+	for _, tt := range tests {
+		t.Run(tt.Name, func(t *testing.T) {
+			err := Unmarshal(buf, tt.v)
+			if err == nil {
+				t.Fatalf("%s: Unmarshal error: got nil, want non-nil", tt.Where)
+			}
+			if got := err.Error(); got != tt.want {
+				t.Errorf("%s: Unmarshal error:\n\tgot:  %s\n\twant: %s", tt.Where, got, tt.want)
+			}
+		})
+	}
 }
 
 func TestInvalidUnmarshalText(t *testing.T) {
 	buf := []byte(`123`)
-	for _, tt := range invalidUnmarshalTextTests {
-		err := Unmarshal(buf, tt.v)
-		if err == nil {
-			t.Errorf("Unmarshal expecting error, got nil")
-			continue
-		}
-		if got := err.Error(); got != tt.want {
-			t.Errorf("Unmarshal = %q; want %q", got, tt.want)
-		}
+	tests := []struct {
+		CaseName
+		v    any
+		want string
+	}{
+		{Name(""), nil, "json: Unmarshal(nil)"},
+		{Name(""), struct{}{}, "json: Unmarshal(non-pointer struct {})"},
+		{Name(""), (*int)(nil), "json: Unmarshal(nil *int)"},
+		{Name(""), new(net.IP), "json: cannot unmarshal number into Go value of type *net.IP"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.Name, func(t *testing.T) {
+			err := Unmarshal(buf, tt.v)
+			if err == nil {
+				t.Fatalf("%s: Unmarshal error: got nil, want non-nil", tt.Where)
+			}
+			if got := err.Error(); got != tt.want {
+				t.Errorf("%s: Unmarshal error:\n\tgot:  %s\n\twant: %s", tt.Where, got, tt.want)
+			}
+		})
 	}
 }
 
@@ -2211,12 +2255,12 @@ func TestInvalidStringOption(t *testing.T) {
 
 	data, err := Marshal(item)
 	if err != nil {
-		t.Fatalf("Marshal: %v", err)
+		t.Fatalf("Marshal error: %v", err)
 	}
 
 	err = Unmarshal(data, &item)
 	if err != nil {
-		t.Fatalf("Unmarshal: %v", err)
+		t.Fatalf("Unmarshal error: %v", err)
 	}
 }
 
@@ -2275,43 +2319,50 @@ func TestUnmarshalEmbeddedUnexported(t *testing.T) {
 	)
 
 	tests := []struct {
+		CaseName
 		in  string
 		ptr any
 		out any
 		err error
 	}{{
 		// Error since we cannot set S1.embed1, but still able to set S1.R.
-		in:  `{"R":2,"Q":1}`,
-		ptr: new(S1),
-		out: &S1{R: 2},
-		err: fmt.Errorf("json: cannot set embedded pointer to unexported struct: json.embed1"),
+		CaseName: Name(""),
+		in:       `{"R":2,"Q":1}`,
+		ptr:      new(S1),
+		out:      &S1{R: 2},
+		err:      fmt.Errorf("json: cannot set embedded pointer to unexported struct: json.embed1"),
 	}, {
 		// The top level Q field takes precedence.
-		in:  `{"Q":1}`,
-		ptr: new(S2),
-		out: &S2{Q: 1},
+		CaseName: Name(""),
+		in:       `{"Q":1}`,
+		ptr:      new(S2),
+		out:      &S2{Q: 1},
 	}, {
 		// No issue with non-pointer variant.
-		in:  `{"R":2,"Q":1}`,
-		ptr: new(S3),
-		out: &S3{embed1: embed1{Q: 1}, R: 2},
+		CaseName: Name(""),
+		in:       `{"R":2,"Q":1}`,
+		ptr:      new(S3),
+		out:      &S3{embed1: embed1{Q: 1}, R: 2},
 	}, {
 		// No error since both embedded structs have field R, which annihilate each other.
 		// Thus, no attempt is made at setting S4.embed1.
-		in:  `{"R":2}`,
-		ptr: new(S4),
-		out: new(S4),
+		CaseName: Name(""),
+		in:       `{"R":2}`,
+		ptr:      new(S4),
+		out:      new(S4),
 	}, {
 		// Error since we cannot set S5.embed1, but still able to set S5.R.
-		in:  `{"R":2,"Q":1}`,
-		ptr: new(S5),
-		out: &S5{R: 2},
-		err: fmt.Errorf("json: cannot set embedded pointer to unexported struct: json.embed3"),
+		CaseName: Name(""),
+		in:       `{"R":2,"Q":1}`,
+		ptr:      new(S5),
+		out:      &S5{R: 2},
+		err:      fmt.Errorf("json: cannot set embedded pointer to unexported struct: json.embed3"),
 	}, {
 		// Issue 24152, ensure decodeState.indirect does not panic.
-		in:  `{"embed1": {"Q": 1}}`,
-		ptr: new(S6),
-		out: &S6{embed1{1}},
+		CaseName: Name(""),
+		in:       `{"embed1": {"Q": 1}}`,
+		ptr:      new(S6),
+		out:      &S6{embed1{1}},
 	}, {
 		// Issue 24153, check that we can still set forwarded fields even in
 		// the presence of a name conflict.
@@ -2325,64 +2376,74 @@ func TestUnmarshalEmbeddedUnexported(t *testing.T) {
 		// it should be impossible for an external package to set either Q.
 		//
 		// It is probably okay for a future reflect change to break this.
-		in:  `{"embed1": {"Q": 1}, "Q": 2}`,
-		ptr: new(S7),
-		out: &S7{embed1{1}, embed2{2}},
+		CaseName: Name(""),
+		in:       `{"embed1": {"Q": 1}, "Q": 2}`,
+		ptr:      new(S7),
+		out:      &S7{embed1{1}, embed2{2}},
 	}, {
 		// Issue 24153, similar to the S7 case.
-		in:  `{"embed1": {"Q": 1}, "embed2": {"Q": 2}, "Q": 3}`,
-		ptr: new(S8),
-		out: &S8{embed1{1}, embed2{2}, 3},
+		CaseName: Name(""),
+		in:       `{"embed1": {"Q": 1}, "embed2": {"Q": 2}, "Q": 3}`,
+		ptr:      new(S8),
+		out:      &S8{embed1{1}, embed2{2}, 3},
 	}, {
 		// Issue 228145, similar to the cases above.
-		in:  `{"embed": {}}`,
-		ptr: new(S9),
-		out: &S9{},
+		CaseName: Name(""),
+		in:       `{"embed": {}}`,
+		ptr:      new(S9),
+		out:      &S9{},
 	}}
-
-	for i, tt := range tests {
-		err := Unmarshal([]byte(tt.in), tt.ptr)
-		if !equalError(err, tt.err) {
-			t.Errorf("#%d: %v, want %v", i, err, tt.err)
-		}
-		if !reflect.DeepEqual(tt.ptr, tt.out) {
-			t.Errorf("#%d: mismatch\ngot:  %#+v\nwant: %#+v", i, tt.ptr, tt.out)
-		}
+	for _, tt := range tests {
+		t.Run(tt.Name, func(t *testing.T) {
+			err := Unmarshal([]byte(tt.in), tt.ptr)
+			if !equalError(err, tt.err) {
+				t.Errorf("%s: Unmarshal error:\n\tgot:  %v\n\twant: %v", tt.Where, err, tt.err)
+			}
+			if !reflect.DeepEqual(tt.ptr, tt.out) {
+				t.Errorf("%s: Unmarshal:\n\tgot:  %#+v\n\twant: %#+v", tt.Where, tt.ptr, tt.out)
+			}
+		})
 	}
 }
 
 func TestUnmarshalErrorAfterMultipleJSON(t *testing.T) {
 	tests := []struct {
+		CaseName
 		in  string
 		err error
 	}{{
-		in:  `1 false null :`,
-		err: &SyntaxError{"invalid character ':' looking for beginning of value", 14},
+		CaseName: Name(""),
+		in:       `1 false null :`,
+		err:      &SyntaxError{"invalid character ':' looking for beginning of value", 14},
 	}, {
-		in:  `1 [] [,]`,
-		err: &SyntaxError{"invalid character ',' looking for beginning of value", 7},
+		CaseName: Name(""),
+		in:       `1 [] [,]`,
+		err:      &SyntaxError{"invalid character ',' looking for beginning of value", 7},
 	}, {
-		in:  `1 [] [true:]`,
-		err: &SyntaxError{"invalid character ':' after array element", 11},
+		CaseName: Name(""),
+		in:       `1 [] [true:]`,
+		err:      &SyntaxError{"invalid character ':' after array element", 11},
 	}, {
-		in:  `1  {}    {"x"=}`,
-		err: &SyntaxError{"invalid character '=' after object key", 14},
+		CaseName: Name(""),
+		in:       `1  {}    {"x"=}`,
+		err:      &SyntaxError{"invalid character '=' after object key", 14},
 	}, {
-		in:  `falsetruenul#`,
-		err: &SyntaxError{"invalid character '#' in literal null (expecting 'l')", 13},
+		CaseName: Name(""),
+		in:       `falsetruenul#`,
+		err:      &SyntaxError{"invalid character '#' in literal null (expecting 'l')", 13},
 	}}
-	for i, tt := range tests {
-		dec := NewDecoder(strings.NewReader(tt.in))
-		var err error
-		for {
-			var v any
-			if err = dec.Decode(&v); err != nil {
-				break
+	for _, tt := range tests {
+		t.Run(tt.Name, func(t *testing.T) {
+			dec := NewDecoder(strings.NewReader(tt.in))
+			var err error
+			for err == nil {
+				var v any
+				err = dec.Decode(&v)
 			}
-		}
-		if !reflect.DeepEqual(err, tt.err) {
-			t.Errorf("#%d: got %#v, want %#v", i, err, tt.err)
-		}
+			if !reflect.DeepEqual(err, tt.err) {
+				t.Errorf("%s: Decode error:\n\tgot:  %v\n\twant: %v", tt.Where, err, tt.err)
+			}
+		})
 	}
 }
 
@@ -2408,7 +2469,7 @@ func TestUnmarshalRecursivePointer(t *testing.T) {
 	data := []byte(`{"a": "b"}`)
 
 	if err := Unmarshal(data, v); err != nil {
-		t.Fatal(err)
+		t.Fatalf("Unmarshal error: %v", err)
 	}
 }
 
@@ -2424,11 +2485,11 @@ func (m *textUnmarshalerString) UnmarshalText(text []byte) error {
 func TestUnmarshalMapWithTextUnmarshalerStringKey(t *testing.T) {
 	var p map[textUnmarshalerString]string
 	if err := Unmarshal([]byte(`{"FOO": "1"}`), &p); err != nil {
-		t.Fatalf("Unmarshal unexpected error: %v", err)
+		t.Fatalf("Unmarshal error: %v", err)
 	}
 
 	if _, ok := p["foo"]; !ok {
-		t.Errorf(`Key "foo" does not exist in map: %v`, p)
+		t.Errorf(`key "foo" missing in map: %v`, p)
 	}
 }
 
@@ -2436,28 +2497,28 @@ func TestUnmarshalRescanLiteralMangledUnquote(t *testing.T) {
 	// See golang.org/issues/38105.
 	var p map[textUnmarshalerString]string
 	if err := Unmarshal([]byte(`{"开源":"12345开源"}`), &p); err != nil {
-		t.Fatalf("Unmarshal unexpected error: %v", err)
+		t.Fatalf("Unmarshal error: %v", err)
 	}
 	if _, ok := p["开源"]; !ok {
-		t.Errorf(`Key "开源" does not exist in map: %v`, p)
+		t.Errorf(`key "开源" missing in map: %v`, p)
 	}
 
 	// See golang.org/issues/38126.
 	type T struct {
 		F1 string `json:"F1,string"`
 	}
-	t1 := T{"aaa\tbbb"}
+	wantT := T{"aaa\tbbb"}
 
-	b, err := Marshal(t1)
+	b, err := Marshal(wantT)
 	if err != nil {
-		t.Fatalf("Marshal unexpected error: %v", err)
+		t.Fatalf("Marshal error: %v", err)
 	}
-	var t2 T
-	if err := Unmarshal(b, &t2); err != nil {
-		t.Fatalf("Unmarshal unexpected error: %v", err)
+	var gotT T
+	if err := Unmarshal(b, &gotT); err != nil {
+		t.Fatalf("Unmarshal error: %v", err)
 	}
-	if t1 != t2 {
-		t.Errorf("Marshal and Unmarshal roundtrip mismatch: want %q got %q", t1, t2)
+	if gotT != wantT {
+		t.Errorf("Marshal/Unmarshal roundtrip:\n\tgot:  %q\n\twant: %q", gotT, wantT)
 	}
 
 	// See golang.org/issues/39555.
@@ -2465,107 +2526,93 @@ func TestUnmarshalRescanLiteralMangledUnquote(t *testing.T) {
 
 	encoded, err := Marshal(input)
 	if err != nil {
-		t.Fatalf("Marshal unexpected error: %v", err)
+		t.Fatalf("Marshal error: %v", err)
 	}
 	var got map[textUnmarshalerString]string
 	if err := Unmarshal(encoded, &got); err != nil {
-		t.Fatalf("Unmarshal unexpected error: %v", err)
+		t.Fatalf("Unmarshal error: %v", err)
 	}
 	want := map[textUnmarshalerString]string{"foo": "", `"`: ""}
-	if !reflect.DeepEqual(want, got) {
-		t.Fatalf("Unexpected roundtrip result:\nwant: %q\ngot:  %q", want, got)
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("Marshal/Unmarshal roundtrip:\n\tgot:  %q\n\twant: %q", gotT, wantT)
 	}
 }
 
 func TestUnmarshalMaxDepth(t *testing.T) {
-	testcases := []struct {
-		name        string
+	tests := []struct {
+		CaseName
 		data        string
 		errMaxDepth bool
-	}{
-		{
-			name:        "ArrayUnderMaxNestingDepth",
-			data:        `{"a":` + strings.Repeat(`[`, 10000-1) + strings.Repeat(`]`, 10000-1) + `}`,
-			errMaxDepth: false,
-		},
-		{
-			name:        "ArrayOverMaxNestingDepth",
-			data:        `{"a":` + strings.Repeat(`[`, 10000) + strings.Repeat(`]`, 10000) + `}`,
-			errMaxDepth: true,
-		},
-		{
-			name:        "ArrayOverStackDepth",
-			data:        `{"a":` + strings.Repeat(`[`, 3000000) + strings.Repeat(`]`, 3000000) + `}`,
-			errMaxDepth: true,
-		},
-		{
-			name:        "ObjectUnderMaxNestingDepth",
-			data:        `{"a":` + strings.Repeat(`{"a":`, 10000-1) + `0` + strings.Repeat(`}`, 10000-1) + `}`,
-			errMaxDepth: false,
-		},
-		{
-			name:        "ObjectOverMaxNestingDepth",
-			data:        `{"a":` + strings.Repeat(`{"a":`, 10000) + `0` + strings.Repeat(`}`, 10000) + `}`,
-			errMaxDepth: true,
-		},
-		{
-			name:        "ObjectOverStackDepth",
-			data:        `{"a":` + strings.Repeat(`{"a":`, 3000000) + `0` + strings.Repeat(`}`, 3000000) + `}`,
-			errMaxDepth: true,
-		},
-	}
+	}{{
+		CaseName:    Name("ArrayUnderMaxNestingDepth"),
+		data:        `{"a":` + strings.Repeat(`[`, 10000-1) + strings.Repeat(`]`, 10000-1) + `}`,
+		errMaxDepth: false,
+	}, {
+		CaseName:    Name("ArrayOverMaxNestingDepth"),
+		data:        `{"a":` + strings.Repeat(`[`, 10000) + strings.Repeat(`]`, 10000) + `}`,
+		errMaxDepth: true,
+	}, {
+		CaseName:    Name("ArrayOverStackDepth"),
+		data:        `{"a":` + strings.Repeat(`[`, 3000000) + strings.Repeat(`]`, 3000000) + `}`,
+		errMaxDepth: true,
+	}, {
+		CaseName:    Name("ObjectUnderMaxNestingDepth"),
+		data:        `{"a":` + strings.Repeat(`{"a":`, 10000-1) + `0` + strings.Repeat(`}`, 10000-1) + `}`,
+		errMaxDepth: false,
+	}, {
+		CaseName:    Name("ObjectOverMaxNestingDepth"),
+		data:        `{"a":` + strings.Repeat(`{"a":`, 10000) + `0` + strings.Repeat(`}`, 10000) + `}`,
+		errMaxDepth: true,
+	}, {
+		CaseName:    Name("ObjectOverStackDepth"),
+		data:        `{"a":` + strings.Repeat(`{"a":`, 3000000) + `0` + strings.Repeat(`}`, 3000000) + `}`,
+		errMaxDepth: true,
+	}}
 
 	targets := []struct {
-		name     string
+		CaseName
 		newValue func() any
-	}{
-		{
-			name: "unstructured",
-			newValue: func() any {
-				var v any
-				return &v
-			},
+	}{{
+		CaseName: Name("unstructured"),
+		newValue: func() any {
+			var v any
+			return &v
 		},
-		{
-			name: "typed named field",
-			newValue: func() any {
-				v := struct {
-					A any `json:"a"`
-				}{}
-				return &v
-			},
+	}, {
+		CaseName: Name("typed named field"),
+		newValue: func() any {
+			v := struct {
+				A any `json:"a"`
+			}{}
+			return &v
 		},
-		{
-			name: "typed missing field",
-			newValue: func() any {
-				v := struct {
-					B any `json:"b"`
-				}{}
-				return &v
-			},
+	}, {
+		CaseName: Name("typed missing field"),
+		newValue: func() any {
+			v := struct {
+				B any `json:"b"`
+			}{}
+			return &v
 		},
-		{
-			name: "custom unmarshaler",
-			newValue: func() any {
-				v := unmarshaler{}
-				return &v
-			},
+	}, {
+		CaseName: Name("custom unmarshaler"),
+		newValue: func() any {
+			v := unmarshaler{}
+			return &v
 		},
-	}
+	}}
 
-	for _, tc := range testcases {
+	for _, tt := range tests {
 		for _, target := range targets {
-			t.Run(target.name+"-"+tc.name, func(t *testing.T) {
-				err := Unmarshal([]byte(tc.data), target.newValue())
-				if !tc.errMaxDepth {
+			t.Run(target.Name+"-"+tt.Name, func(t *testing.T) {
+				err := Unmarshal([]byte(tt.data), target.newValue())
+				if !tt.errMaxDepth {
 					if err != nil {
-						t.Errorf("unexpected error: %v", err)
+						t.Errorf("%s: %s: Unmarshal error: %v", tt.Where, target.Where, err)
 					}
 				} else {
-					if err == nil {
-						t.Errorf("expected error containing 'exceeded max depth', got none")
-					} else if !strings.Contains(err.Error(), "exceeded max depth") {
-						t.Errorf("expected error containing 'exceeded max depth', got: %v", err)
+					if err == nil || !strings.Contains(err.Error(), "exceeded max depth") {
+						t.Errorf("%s: %s: Unmarshal error:\n\tgot:  %v\n\twant: exceeded max depth", tt.Where, target.Where, err)
 					}
 				}
 			})

--- a/internal/golang/encoding/json/encode.go
+++ b/internal/golang/encoding/json/encode.go
@@ -12,45 +12,48 @@ package json
 
 import (
 	"bytes"
+	"cmp"
 	"encoding"
 	"encoding/base64"
 	"fmt"
 	"math"
 	"reflect"
-	"sort"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
 	"unicode"
 	"unicode/utf8"
+	_ "unsafe" // for linkname
 )
 
 // Marshal returns the JSON encoding of v.
 //
 // Marshal traverses the value v recursively.
-// If an encountered value implements the Marshaler interface
-// and is not a nil pointer, Marshal calls its MarshalJSON method
-// to produce JSON. If no MarshalJSON method is present but the
-// value implements encoding.TextMarshaler instead, Marshal calls
-// its MarshalText method and encodes the result as a JSON string.
+// If an encountered value implements [Marshaler]
+// and is not a nil pointer, Marshal calls [Marshaler.MarshalJSON]
+// to produce JSON. If no [Marshaler.MarshalJSON] method is present but the
+// value implements [encoding.TextMarshaler] instead, Marshal calls
+// [encoding.TextMarshaler.MarshalText] and encodes the result as a JSON string.
 // The nil pointer exception is not strictly necessary
 // but mimics a similar, necessary exception in the behavior of
-// UnmarshalJSON.
+// [Unmarshaler.UnmarshalJSON].
 //
 // Otherwise, Marshal uses the following type-dependent default encodings:
 //
 // Boolean values encode as JSON booleans.
 //
-// Floating point, integer, and Number values encode as JSON numbers.
+// Floating point, integer, and [Number] values encode as JSON numbers.
+// NaN and +/-Inf values will return an [UnsupportedValueError].
 //
 // String values encode as JSON strings coerced to valid UTF-8,
 // replacing invalid bytes with the Unicode replacement rune.
 // So that the JSON will be safe to embed inside HTML <script> tags,
-// the string is encoded using HTMLEscape,
+// the string is encoded using [HTMLEscape],
 // which replaces "<", ">", "&", U+2028, and U+2029 are escaped
 // to "\u003c","\u003e", "\u0026", "\u2028", and "\u2029".
-// This replacement can be disabled when using an Encoder,
-// by calling SetEscapeHTML(false).
+// This replacement can be disabled when using an [Encoder],
+// by calling [Encoder.SetEscapeHTML](false).
 //
 // Array and slice values encode as JSON arrays, except that
 // []byte encodes as a base64-encoded string, and a nil slice
@@ -107,7 +110,7 @@ import (
 // only Unicode letters, digits, and ASCII punctuation except quotation
 // marks, backslash, and comma.
 //
-// Anonymous struct fields are usually marshaled as if their inner exported fields
+// Embedded struct fields are usually marshaled as if their inner exported fields
 // were fields in the outer struct, subject to the usual Go visibility rules amended
 // as described in the next paragraph.
 // An anonymous struct field with a name given in its JSON tag is treated as
@@ -134,11 +137,11 @@ import (
 // a JSON tag of "-".
 //
 // Map values encode as JSON objects. The map's key type must either be a
-// string, an integer type, or implement encoding.TextMarshaler. The map keys
+// string, an integer type, or implement [encoding.TextMarshaler]. The map keys
 // are sorted and used as JSON object keys by applying the following rules,
 // subject to the UTF-8 coercion described for string values above:
 //   - keys of any string type are used directly
-//   - encoding.TextMarshalers are marshaled
+//   - keys that implement [encoding.TextMarshaler] are marshaled
 //   - integer keys are converted to strings
 //
 // Pointer values encode as the value pointed to.
@@ -149,13 +152,14 @@ import (
 //
 // Channel, complex, and function values cannot be encoded in JSON.
 // Attempting to encode such a value causes Marshal to return
-// an UnsupportedTypeError.
+// an [UnsupportedTypeError].
 //
 // JSON cannot represent cyclic data structures and Marshal does not
 // handle them. Passing cyclic structures to Marshal will result in
 // an error.
 func Marshal(v any) ([]byte, error) {
 	e := newEncodeState()
+	defer encodeStatePool.Put(e)
 
 	err := e.marshal(v, encOpts{escapeHTML: true})
 	if err != nil {
@@ -163,12 +167,10 @@ func Marshal(v any) ([]byte, error) {
 	}
 	buf := append([]byte(nil), e.Bytes()...)
 
-	encodeStatePool.Put(e)
-
 	return buf, nil
 }
 
-// MarshalIndent is like Marshal but applies Indent to format the output.
+// MarshalIndent is like [Marshal] but applies [Indent] to format the output.
 // Each JSON element in the output will begin on a new line beginning with prefix
 // followed by one or more copies of indent according to the indentation nesting.
 func MarshalIndent(v any, prefix, indent string) ([]byte, error) {
@@ -176,47 +178,12 @@ func MarshalIndent(v any, prefix, indent string) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	var buf bytes.Buffer
-	err = Indent(&buf, b, prefix, indent)
+	b2 := make([]byte, 0, indentGrowthFactor*len(b))
+	b2, err = appendIndent(b2, b, prefix, indent)
 	if err != nil {
 		return nil, err
 	}
-	return buf.Bytes(), nil
-}
-
-// HTMLEscape appends to dst the JSON-encoded src with <, >, &, U+2028 and U+2029
-// characters inside string literals changed to \u003c, \u003e, \u0026, \u2028, \u2029
-// so that the JSON will be safe to embed inside HTML <script> tags.
-// For historical reasons, web browsers don't honor standard HTML
-// escaping within <script> tags, so an alternative JSON encoding must
-// be used.
-func HTMLEscape(dst *bytes.Buffer, src []byte) {
-	// The characters can only appear in string literals,
-	// so just scan the string one byte at a time.
-	start := 0
-	for i, c := range src {
-		if c == '<' || c == '>' || c == '&' {
-			if start < i {
-				dst.Write(src[start:i])
-			}
-			dst.WriteString(`\u00`)
-			dst.WriteByte(hex[c>>4])
-			dst.WriteByte(hex[c&0xF])
-			start = i + 1
-		}
-		// Convert U+2028 and U+2029 (E2 80 A8 and E2 80 A9).
-		if c == 0xE2 && i+2 < len(src) && src[i+1] == 0x80 && src[i+2]&^1 == 0xA8 {
-			if start < i {
-				dst.Write(src[start:i])
-			}
-			dst.WriteString(`\u202`)
-			dst.WriteByte(hex[src[i+2]&0xF])
-			start = i + 3
-		}
-	}
-	if start < len(src) {
-		dst.Write(src[start:])
-	}
+	return b2, nil
 }
 
 // Marshaler is the interface implemented by types that
@@ -225,7 +192,7 @@ type Marshaler interface {
 	MarshalJSON() ([]byte, error)
 }
 
-// An UnsupportedTypeError is returned by Marshal when attempting
+// An UnsupportedTypeError is returned by [Marshal] when attempting
 // to encode an unsupported value type.
 type UnsupportedTypeError struct {
 	Type reflect.Type
@@ -235,7 +202,7 @@ func (e *UnsupportedTypeError) Error() string {
 	return "json: unsupported type: " + e.Type.String()
 }
 
-// An UnsupportedValueError is returned by Marshal when attempting
+// An UnsupportedValueError is returned by [Marshal] when attempting
 // to encode an unsupported value.
 type UnsupportedValueError struct {
 	Value reflect.Value
@@ -246,9 +213,9 @@ func (e *UnsupportedValueError) Error() string {
 	return "json: unsupported value: " + e.Str
 }
 
-// Before Go 1.2, an InvalidUTF8Error was returned by Marshal when
+// Before Go 1.2, an InvalidUTF8Error was returned by [Marshal] when
 // attempting to encode a string value with invalid UTF-8 sequences.
-// As of Go 1.2, Marshal instead coerces the string to valid UTF-8 by
+// As of Go 1.2, [Marshal] instead coerces the string to valid UTF-8 by
 // replacing invalid bytes with the Unicode replacement rune U+FFFD.
 //
 // Deprecated: No longer used; kept for compatibility.
@@ -260,7 +227,8 @@ func (e *InvalidUTF8Error) Error() string {
 	return "json: invalid UTF-8 in string: " + strconv.Quote(e.S)
 }
 
-// A MarshalerError represents an error from calling a MarshalJSON or MarshalText method.
+// A MarshalerError represents an error from calling a
+// [Marshaler.MarshalJSON] or [encoding.TextMarshaler.MarshalText] method.
 type MarshalerError struct {
 	Type       reflect.Type
 	Err        error
@@ -280,12 +248,11 @@ func (e *MarshalerError) Error() string {
 // Unwrap returns the underlying error.
 func (e *MarshalerError) Unwrap() error { return e.Err }
 
-var hex = "0123456789abcdef"
+const hex = "0123456789abcdef"
 
 // An encodeState encodes JSON into a bytes.Buffer.
 type encodeState struct {
 	bytes.Buffer // accumulated output
-	scratch      [64]byte
 
 	// Keep track of what pointers we've seen in the current recursive call
 	// path, to avoid cycles that could lead to a stack overflow. Only do
@@ -341,16 +308,12 @@ func isEmptyValue(v reflect.Value) bool {
 	switch v.Kind() {
 	case reflect.Array, reflect.Map, reflect.Slice, reflect.String:
 		return v.Len() == 0
-	case reflect.Bool:
-		return !v.Bool()
-	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
-		return v.Int() == 0
-	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
-		return v.Uint() == 0
-	case reflect.Float32, reflect.Float64:
-		return v.Float() == 0
-	case reflect.Interface, reflect.Pointer:
-		return v.IsNil()
+	case reflect.Bool,
+		reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64,
+		reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr,
+		reflect.Float32, reflect.Float64,
+		reflect.Interface, reflect.Pointer:
+		return v.IsZero()
 	}
 	return false
 }
@@ -407,8 +370,8 @@ func typeEncoder(t reflect.Type) encoderFunc {
 }
 
 var (
-	marshalerType     = reflect.TypeOf((*Marshaler)(nil)).Elem()
-	textMarshalerType = reflect.TypeOf((*encoding.TextMarshaler)(nil)).Elem()
+	marshalerType     = reflect.TypeFor[Marshaler]()
+	textMarshalerType = reflect.TypeFor[encoding.TextMarshaler]()
 )
 
 // newTypeEncoder constructs an encoderFunc for a type.
@@ -477,8 +440,10 @@ func marshalerEncoder(e *encodeState, v reflect.Value, opts encOpts) {
 	}
 	b, err := m.MarshalJSON()
 	if err == nil {
-		// copy JSON into buffer, checking validity.
-		err = compact(&e.Buffer, b, opts.escapeHTML)
+		e.Grow(len(b))
+		out := e.AvailableBuffer()
+		out, err = appendCompact(out, b, opts.escapeHTML)
+		e.Buffer.Write(out)
 	}
 	if err != nil {
 		e.error(&MarshalerError{v.Type(), err, "MarshalJSON"})
@@ -494,8 +459,10 @@ func addrMarshalerEncoder(e *encodeState, v reflect.Value, opts encOpts) {
 	m := va.Interface().(Marshaler)
 	b, err := m.MarshalJSON()
 	if err == nil {
-		// copy JSON into buffer, checking validity.
-		err = compact(&e.Buffer, b, opts.escapeHTML)
+		e.Grow(len(b))
+		out := e.AvailableBuffer()
+		out, err = appendCompact(out, b, opts.escapeHTML)
+		e.Buffer.Write(out)
 	}
 	if err != nil {
 		e.error(&MarshalerError{v.Type(), err, "MarshalJSON"})
@@ -516,7 +483,7 @@ func textMarshalerEncoder(e *encodeState, v reflect.Value, opts encOpts) {
 	if err != nil {
 		e.error(&MarshalerError{v.Type(), err, "MarshalText"})
 	}
-	e.stringBytes(b, opts.escapeHTML)
+	e.Write(appendString(e.AvailableBuffer(), b, opts.escapeHTML))
 }
 
 func addrTextMarshalerEncoder(e *encodeState, v reflect.Value, opts encOpts) {
@@ -530,43 +497,31 @@ func addrTextMarshalerEncoder(e *encodeState, v reflect.Value, opts encOpts) {
 	if err != nil {
 		e.error(&MarshalerError{v.Type(), err, "MarshalText"})
 	}
-	e.stringBytes(b, opts.escapeHTML)
+	e.Write(appendString(e.AvailableBuffer(), b, opts.escapeHTML))
 }
 
 func boolEncoder(e *encodeState, v reflect.Value, opts encOpts) {
-	if opts.quoted {
-		e.WriteByte('"')
-	}
-	if v.Bool() {
-		e.WriteString("true")
-	} else {
-		e.WriteString("false")
-	}
-	if opts.quoted {
-		e.WriteByte('"')
-	}
+	b := e.AvailableBuffer()
+	b = mayAppendQuote(b, opts.quoted)
+	b = strconv.AppendBool(b, v.Bool())
+	b = mayAppendQuote(b, opts.quoted)
+	e.Write(b)
 }
 
 func intEncoder(e *encodeState, v reflect.Value, opts encOpts) {
-	b := strconv.AppendInt(e.scratch[:0], v.Int(), 10)
-	if opts.quoted {
-		e.WriteByte('"')
-	}
+	b := e.AvailableBuffer()
+	b = mayAppendQuote(b, opts.quoted)
+	b = strconv.AppendInt(b, v.Int(), 10)
+	b = mayAppendQuote(b, opts.quoted)
 	e.Write(b)
-	if opts.quoted {
-		e.WriteByte('"')
-	}
 }
 
 func uintEncoder(e *encodeState, v reflect.Value, opts encOpts) {
-	b := strconv.AppendUint(e.scratch[:0], v.Uint(), 10)
-	if opts.quoted {
-		e.WriteByte('"')
-	}
+	b := e.AvailableBuffer()
+	b = mayAppendQuote(b, opts.quoted)
+	b = strconv.AppendUint(b, v.Uint(), 10)
+	b = mayAppendQuote(b, opts.quoted)
 	e.Write(b)
-	if opts.quoted {
-		e.WriteByte('"')
-	}
 }
 
 type floatEncoder int // number of bits
@@ -582,7 +537,8 @@ func (bits floatEncoder) encode(e *encodeState, v reflect.Value, opts encOpts) {
 	// See golang.org/issue/6384 and golang.org/issue/14135.
 	// Like fmt %g, but the exponent cutoffs are different
 	// and exponents themselves are not padded to two digits.
-	b := e.scratch[:0]
+	b := e.AvailableBuffer()
+	b = mayAppendQuote(b, opts.quoted)
 	abs := math.Abs(f)
 	fmt := byte('f')
 	// Note: Must use float32 comparisons for underlying float32 value to get precise cutoffs right.
@@ -600,14 +556,8 @@ func (bits floatEncoder) encode(e *encodeState, v reflect.Value, opts encOpts) {
 			b = b[:n-1]
 		}
 	}
-
-	if opts.quoted {
-		e.WriteByte('"')
-	}
+	b = mayAppendQuote(b, opts.quoted)
 	e.Write(b)
-	if opts.quoted {
-		e.WriteByte('"')
-	}
 }
 
 var (
@@ -626,28 +576,32 @@ func stringEncoder(e *encodeState, v reflect.Value, opts encOpts) {
 		if !isValidNumber(numStr) {
 			e.error(fmt.Errorf("json: invalid number literal %q", numStr))
 		}
-		if opts.quoted {
-			e.WriteByte('"')
-		}
-		e.WriteString(numStr)
-		if opts.quoted {
-			e.WriteByte('"')
-		}
+		b := e.AvailableBuffer()
+		b = mayAppendQuote(b, opts.quoted)
+		b = append(b, numStr...)
+		b = mayAppendQuote(b, opts.quoted)
+		e.Write(b)
 		return
 	}
 	if opts.quoted {
-		e2 := newEncodeState()
-		// Since we encode the string twice, we only need to escape HTML
-		// the first time.
-		e2.string(v.String(), opts.escapeHTML)
-		e.stringBytes(e2.Bytes(), false)
-		encodeStatePool.Put(e2)
+		b := appendString(nil, v.String(), opts.escapeHTML)
+		e.Write(appendString(e.AvailableBuffer(), b, false)) // no need to escape again since it is already escaped
 	} else {
-		e.string(v.String(), opts.escapeHTML)
+		e.Write(appendString(e.AvailableBuffer(), v.String(), opts.escapeHTML))
 	}
 }
 
 // isValidNumber reports whether s is a valid JSON number literal.
+//
+// isValidNumber should be an internal detail,
+// but widely used packages access it using linkname.
+// Notable members of the hall of shame include:
+//   - github.com/bytedance/sonic
+//
+// Do not remove or change the type signature.
+// See go.dev/issue/67401.
+//
+//go:linkname isValidNumber
 func isValidNumber(s string) bool {
 	// This function implements the JSON numbers grammar.
 	// See https://tools.ietf.org/html/rfc7159#section-6
@@ -724,8 +678,9 @@ type structEncoder struct {
 }
 
 type structFields struct {
-	list      []field
-	nameIndex map[string]int
+	list         []field
+	byExactName  map[string]*field
+	byFoldedName map[string]*field
 }
 
 func (se structEncoder) encode(e *encodeState, v reflect.Value, opts encOpts) {
@@ -793,22 +748,26 @@ func (me mapEncoder) encode(e *encodeState, v reflect.Value, opts encOpts) {
 	e.WriteByte('{')
 
 	// Extract and sort the keys.
-	sv := make([]reflectWithString, v.Len())
-	mi := v.MapRange()
+	var (
+		sv  = make([]reflectWithString, v.Len())
+		mi  = v.MapRange()
+		err error
+	)
 	for i := 0; mi.Next(); i++ {
-		sv[i].k = mi.Key()
-		sv[i].v = mi.Value()
-		if err := sv[i].resolve(); err != nil {
+		if sv[i].ks, err = resolveKeyName(mi.Key()); err != nil {
 			e.error(fmt.Errorf("json: encoding error for type %q: %q", v.Type().String(), err.Error()))
 		}
+		sv[i].v = mi.Value()
 	}
-	sort.Slice(sv, func(i, j int) bool { return sv[i].ks < sv[j].ks })
+	slices.SortFunc(sv, func(i, j reflectWithString) int {
+		return strings.Compare(i.ks, j.ks)
+	})
 
 	for i, kv := range sv {
 		if i > 0 {
 			e.WriteByte(',')
 		}
-		e.string(kv.ks, opts.escapeHTML)
+		e.Write(appendString(e.AvailableBuffer(), kv.ks, opts.escapeHTML))
 		e.WriteByte(':')
 		me.elemEnc(e, kv.v, opts)
 	}
@@ -835,29 +794,13 @@ func encodeByteSlice(e *encodeState, v reflect.Value, _ encOpts) {
 		e.WriteString("null")
 		return
 	}
+
 	s := v.Bytes()
-	e.WriteByte('"')
-	encodedLen := base64.StdEncoding.EncodedLen(len(s))
-	if encodedLen <= len(e.scratch) {
-		// If the encoded bytes fit in e.scratch, avoid an extra
-		// allocation and use the cheaper Encoding.Encode.
-		dst := e.scratch[:encodedLen]
-		base64.StdEncoding.Encode(dst, s)
-		e.Write(dst)
-	} else if encodedLen <= 1024 {
-		// The encoded bytes are short enough to allocate for, and
-		// Encoding.Encode is still cheaper.
-		dst := make([]byte, encodedLen)
-		base64.StdEncoding.Encode(dst, s)
-		e.Write(dst)
-	} else {
-		// The encoded bytes are too long to cheaply allocate, and
-		// Encoding.Encode is no longer noticeably cheaper.
-		enc := base64.NewEncoder(base64.StdEncoding, e)
-		enc.Write(s)
-		enc.Close()
-	}
-	e.WriteByte('"')
+	b := e.AvailableBuffer()
+	b = append(b, '"')
+	b = base64.StdEncoding.AppendEncode(b, s)
+	b = append(b, '"')
+	e.Write(b)
 }
 
 // sliceEncoder just wraps an arrayEncoder, checking to make sure the value isn't nil.
@@ -997,78 +940,77 @@ func typeByIndex(t reflect.Type, index []int) reflect.Type {
 }
 
 type reflectWithString struct {
-	k  reflect.Value
 	v  reflect.Value
 	ks string
 }
 
-func (w *reflectWithString) resolve() error {
-	if w.k.Kind() == reflect.String {
-		w.ks = w.k.String()
-		return nil
+func resolveKeyName(k reflect.Value) (string, error) {
+	if k.Kind() == reflect.String {
+		return k.String(), nil
 	}
-	if tm, ok := w.k.Interface().(encoding.TextMarshaler); ok {
-		if w.k.Kind() == reflect.Pointer && w.k.IsNil() {
-			return nil
+	if tm, ok := k.Interface().(encoding.TextMarshaler); ok {
+		if k.Kind() == reflect.Pointer && k.IsNil() {
+			return "", nil
 		}
 		buf, err := tm.MarshalText()
-		w.ks = string(buf)
-		return err
+		return string(buf), err
 	}
-	switch w.k.Kind() {
+	switch k.Kind() {
 	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
-		w.ks = strconv.FormatInt(w.k.Int(), 10)
-		return nil
+		return strconv.FormatInt(k.Int(), 10), nil
 	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
-		w.ks = strconv.FormatUint(w.k.Uint(), 10)
-		return nil
+		return strconv.FormatUint(k.Uint(), 10), nil
 	}
 	panic("unexpected map key type")
 }
 
-// NOTE: keep in sync with stringBytes below.
-func (e *encodeState) string(s string, escapeHTML bool) {
-	e.WriteByte('"')
+func appendString[Bytes []byte | string](dst []byte, src Bytes, escapeHTML bool) []byte {
+	dst = append(dst, '"')
 	start := 0
-	for i := 0; i < len(s); {
-		if b := s[i]; b < utf8.RuneSelf {
+	for i := 0; i < len(src); {
+		if b := src[i]; b < utf8.RuneSelf {
 			if htmlSafeSet[b] || (!escapeHTML && safeSet[b]) {
 				i++
 				continue
 			}
-			if start < i {
-				e.WriteString(s[start:i])
-			}
-			e.WriteByte('\\')
+			dst = append(dst, src[start:i]...)
 			switch b {
 			case '\\', '"':
-				e.WriteByte(b)
+				dst = append(dst, '\\', b)
+			case '\b':
+				dst = append(dst, '\\', 'b')
+			case '\f':
+				dst = append(dst, '\\', 'f')
 			case '\n':
-				e.WriteByte('n')
+				dst = append(dst, '\\', 'n')
 			case '\r':
-				e.WriteByte('r')
+				dst = append(dst, '\\', 'r')
 			case '\t':
-				e.WriteByte('t')
+				dst = append(dst, '\\', 't')
 			default:
-				// This encodes bytes < 0x20 except for \t, \n and \r.
+				// This encodes bytes < 0x20 except for \b, \f, \n, \r and \t.
 				// If escapeHTML is set, it also escapes <, >, and &
 				// because they can lead to security holes when
 				// user-controlled strings are rendered into JSON
 				// and served to some browsers.
-				e.WriteString(`u00`)
-				e.WriteByte(hex[b>>4])
-				e.WriteByte(hex[b&0xF])
+				dst = append(dst, '\\', 'u', '0', '0', hex[b>>4], hex[b&0xF])
 			}
 			i++
 			start = i
 			continue
 		}
-		c, size := utf8.DecodeRuneInString(s[i:])
+		// TODO(https://go.dev/issue/56948): Use generic utf8 functionality.
+		// For now, cast only a small portion of byte slices to a string
+		// so that it can be stack allocated. This slows down []byte slightly
+		// due to the extra copy, but keeps string performance roughly the same.
+		n := len(src) - i
+		if n > utf8.UTFMax {
+			n = utf8.UTFMax
+		}
+		c, size := utf8.DecodeRuneInString(string(src[i : i+n]))
 		if c == utf8.RuneError && size == 1 {
-			if start < i {
-				e.WriteString(s[start:i])
-			}
-			e.WriteString(`\ufffd`)
+			dst = append(dst, src[start:i]...)
+			dst = append(dst, `\ufffd`...)
 			i += size
 			start = i
 			continue
@@ -1079,102 +1021,25 @@ func (e *encodeState) string(s string, escapeHTML bool) {
 		// but don't work in JSONP, which has to be evaluated as JavaScript,
 		// and can lead to security holes there. It is valid JSON to
 		// escape them, so we do so unconditionally.
-		// See http://timelessrepo.com/json-isnt-a-javascript-subset for discussion.
+		// See https://en.wikipedia.org/wiki/JSON#Safety.
 		if c == '\u2028' || c == '\u2029' {
-			if start < i {
-				e.WriteString(s[start:i])
-			}
-			e.WriteString(`\u202`)
-			e.WriteByte(hex[c&0xF])
+			dst = append(dst, src[start:i]...)
+			dst = append(dst, '\\', 'u', '2', '0', '2', hex[c&0xF])
 			i += size
 			start = i
 			continue
 		}
 		i += size
 	}
-	if start < len(s) {
-		e.WriteString(s[start:])
-	}
-	e.WriteByte('"')
-}
-
-// NOTE: keep in sync with string above.
-func (e *encodeState) stringBytes(s []byte, escapeHTML bool) {
-	e.WriteByte('"')
-	start := 0
-	for i := 0; i < len(s); {
-		if b := s[i]; b < utf8.RuneSelf {
-			if htmlSafeSet[b] || (!escapeHTML && safeSet[b]) {
-				i++
-				continue
-			}
-			if start < i {
-				e.Write(s[start:i])
-			}
-			e.WriteByte('\\')
-			switch b {
-			case '\\', '"':
-				e.WriteByte(b)
-			case '\n':
-				e.WriteByte('n')
-			case '\r':
-				e.WriteByte('r')
-			case '\t':
-				e.WriteByte('t')
-			default:
-				// This encodes bytes < 0x20 except for \t, \n and \r.
-				// If escapeHTML is set, it also escapes <, >, and &
-				// because they can lead to security holes when
-				// user-controlled strings are rendered into JSON
-				// and served to some browsers.
-				e.WriteString(`u00`)
-				e.WriteByte(hex[b>>4])
-				e.WriteByte(hex[b&0xF])
-			}
-			i++
-			start = i
-			continue
-		}
-		c, size := utf8.DecodeRune(s[i:])
-		if c == utf8.RuneError && size == 1 {
-			if start < i {
-				e.Write(s[start:i])
-			}
-			e.WriteString(`\ufffd`)
-			i += size
-			start = i
-			continue
-		}
-		// U+2028 is LINE SEPARATOR.
-		// U+2029 is PARAGRAPH SEPARATOR.
-		// They are both technically valid characters in JSON strings,
-		// but don't work in JSONP, which has to be evaluated as JavaScript,
-		// and can lead to security holes there. It is valid JSON to
-		// escape them, so we do so unconditionally.
-		// See http://timelessrepo.com/json-isnt-a-javascript-subset for discussion.
-		if c == '\u2028' || c == '\u2029' {
-			if start < i {
-				e.Write(s[start:i])
-			}
-			e.WriteString(`\u202`)
-			e.WriteByte(hex[c&0xF])
-			i += size
-			start = i
-			continue
-		}
-		i += size
-	}
-	if start < len(s) {
-		e.Write(s[start:])
-	}
-	e.WriteByte('"')
+	dst = append(dst, src[start:]...)
+	dst = append(dst, '"')
+	return dst
 }
 
 // A field represents a single field found in a struct.
 type field struct {
 	name      string
-	nameBytes []byte                 // []byte(name)
-	equalFold func(s, t []byte) bool // bytes.EqualFold or equivalent
+	nameBytes []byte // []byte(name)
 
 	nameNonEsc  string // `"` + name + `":`
 	nameEscHTML string // `"` + HTMLEscape(name) + `":`
@@ -1188,28 +1053,19 @@ type field struct {
 	encoder encoderFunc
 }
 
-// byIndex sorts field by index sequence.
-type byIndex []field
-
-func (x byIndex) Len() int { return len(x) }
-
-func (x byIndex) Swap(i, j int) { x[i], x[j] = x[j], x[i] }
-
-func (x byIndex) Less(i, j int) bool {
-	for k, xik := range x[i].index {
-		if k >= len(x[j].index) {
-			return false
-		}
-		if xik != x[j].index[k] {
-			return xik < x[j].index[k]
-		}
-	}
-	return len(x[i].index) < len(x[j].index)
-}
-
 // typeFields returns a list of fields that JSON should recognize for the given type.
 // The algorithm is breadth-first search over the set of structs to include - the top struct
 // and then any reachable anonymous structs.
+//
+// typeFields should be an internal detail,
+// but widely used packages access it using linkname.
+// Notable members of the hall of shame include:
+//   - github.com/bytedance/sonic
+//
+// Do not remove or change the type signature.
+// See go.dev/issue/67401.
+//
+//go:linkname typeFields
 func typeFields(t reflect.Type) structFields {
 	// Anonymous fields to explore at the current level and the next.
 	current := []field{}
@@ -1224,8 +1080,8 @@ func typeFields(t reflect.Type) structFields {
 	// Fields found.
 	var fields []field
 
-	// Buffer to run HTMLEscape on field names.
-	var nameEscBuf bytes.Buffer
+	// Buffer to run appendHTMLEscape on field names.
+	var nameEscBuf []byte
 
 	for len(next) > 0 {
 		current, next = next, current[:0]
@@ -1301,21 +1157,17 @@ func typeFields(t reflect.Type) structFields {
 						quoted:    quoted,
 					}
 					field.nameBytes = []byte(field.name)
-					field.equalFold = foldFunc(field.nameBytes)
 
 					// Build nameEscHTML and nameNonEsc ahead of time.
-					nameEscBuf.Reset()
-					nameEscBuf.WriteString(`"`)
-					HTMLEscape(&nameEscBuf, field.nameBytes)
-					nameEscBuf.WriteString(`":`)
-					field.nameEscHTML = nameEscBuf.String()
+					nameEscBuf = appendHTMLEscape(nameEscBuf[:0], field.nameBytes)
+					field.nameEscHTML = `"` + string(nameEscBuf) + `":`
 					field.nameNonEsc = `"` + field.name + `":`
 
 					fields = append(fields, field)
 					if count[f.typ] > 1 {
 						// If there were multiple instances, add a second,
 						// so that the annihilation code will see a duplicate.
-						// It only cares about the distinction between 1 or 2,
+						// It only cares about the distinction between 1 and 2,
 						// so don't bother generating any more copies.
 						fields = append(fields, fields[len(fields)-1])
 					}
@@ -1331,21 +1183,23 @@ func typeFields(t reflect.Type) structFields {
 		}
 	}
 
-	sort.Slice(fields, func(i, j int) bool {
-		x := fields
+	slices.SortFunc(fields, func(a, b field) int {
 		// sort field by name, breaking ties with depth, then
 		// breaking ties with "name came from json tag", then
 		// breaking ties with index sequence.
-		if x[i].name != x[j].name {
-			return x[i].name < x[j].name
+		if c := strings.Compare(a.name, b.name); c != 0 {
+			return c
 		}
-		if len(x[i].index) != len(x[j].index) {
-			return len(x[i].index) < len(x[j].index)
+		if c := cmp.Compare(len(a.index), len(b.index)); c != 0 {
+			return c
 		}
-		if x[i].tag != x[j].tag {
-			return x[i].tag
+		if a.tag != b.tag {
+			if a.tag {
+				return -1
+			}
+			return +1
 		}
-		return byIndex(x).Less(i, j)
+		return slices.Compare(a.index, b.index)
 	})
 
 	// Delete all fields that are hidden by the Go rules for embedded fields,
@@ -1377,17 +1231,24 @@ func typeFields(t reflect.Type) structFields {
 	}
 
 	fields = out
-	sort.Sort(byIndex(fields))
+	slices.SortFunc(fields, func(i, j field) int {
+		return slices.Compare(i.index, j.index)
+	})
 
 	for i := range fields {
 		f := &fields[i]
 		f.encoder = typeEncoder(typeByIndex(t, f.index))
 	}
-	nameIndex := make(map[string]int, len(fields))
+	exactNameIndex := make(map[string]*field, len(fields))
+	foldedNameIndex := make(map[string]*field, len(fields))
 	for i, field := range fields {
-		nameIndex[field.name] = i
+		exactNameIndex[field.name] = &fields[i]
+		// For historical reasons, first folded match takes precedence.
+		if _, ok := foldedNameIndex[string(foldName(field.nameBytes))]; !ok {
+			foldedNameIndex[string(foldName(field.nameBytes))] = &fields[i]
+		}
 	}
-	return structFields{fields, nameIndex}
+	return structFields{fields, exactNameIndex, foldedNameIndex}
 }
 
 // dominantField looks through the fields, all of which are known to
@@ -1415,4 +1276,11 @@ func cachedTypeFields(t reflect.Type) structFields {
 	}
 	f, _ := fieldCache.LoadOrStore(t, typeFields(t))
 	return f.(structFields)
+}
+
+func mayAppendQuote(b []byte, quoted bool) []byte {
+	if quoted {
+		b = append(b, '"')
+	}
+	return b
 }

--- a/internal/golang/encoding/json/encode_test.go
+++ b/internal/golang/encoding/json/encode_test.go
@@ -12,9 +12,9 @@ import (
 	"math"
 	"reflect"
 	"regexp"
+	"runtime/debug"
 	"strconv"
 	"testing"
-	"unicode"
 )
 
 type Optionals struct {
@@ -44,7 +44,8 @@ type Optionals struct {
 	Sto struct{} `json:"sto,omitempty"`
 }
 
-var optionalsExpected = `{
+func TestOmitEmpty(t *testing.T) {
+	var want = `{
  "sr": "",
  "omitempty": 0,
  "slr": null,
@@ -55,8 +56,6 @@ var optionalsExpected = `{
  "str": {},
  "sto": {}
 }`
-
-func TestOmitEmpty(t *testing.T) {
 	var o Optionals
 	o.Sw = "something"
 	o.Mr = map[string]any{}
@@ -64,10 +63,10 @@ func TestOmitEmpty(t *testing.T) {
 
 	got, err := MarshalIndent(&o, "", " ")
 	if err != nil {
-		t.Fatal(err)
+		t.Fatalf("MarshalIndent error: %v", err)
 	}
-	if got := string(got); got != optionalsExpected {
-		t.Errorf(" got: %s\nwant: %s\n", got, optionalsExpected)
+	if got := string(got); got != want {
+		t.Errorf("MarshalIndent:\n\tgot:  %s\n\twant: %s\n", indentNewlines(got), indentNewlines(want))
 	}
 }
 
@@ -81,62 +80,57 @@ type StringTag struct {
 
 func TestRoundtripStringTag(t *testing.T) {
 	tests := []struct {
-		name string
+		CaseName
 		in   StringTag
 		want string // empty to just test that we roundtrip
-	}{
-		{
-			name: "AllTypes",
-			in: StringTag{
-				BoolStr:    true,
-				IntStr:     42,
-				UintptrStr: 44,
-				StrStr:     "xzbit",
-				NumberStr:  "46",
-			},
-			want: `{
-				"BoolStr": "true",
-				"IntStr": "42",
-				"UintptrStr": "44",
-				"StrStr": "\"xzbit\"",
-				"NumberStr": "46"
-			}`,
+	}{{
+		CaseName: Name("AllTypes"),
+		in: StringTag{
+			BoolStr:    true,
+			IntStr:     42,
+			UintptrStr: 44,
+			StrStr:     "xzbit",
+			NumberStr:  "46",
 		},
-		{
-			// See golang.org/issues/38173.
-			name: "StringDoubleEscapes",
-			in: StringTag{
-				StrStr:    "\b\f\n\r\t\"\\",
-				NumberStr: "0", // just to satisfy the roundtrip
-			},
-			want: `{
-				"BoolStr": "false",
-				"IntStr": "0",
-				"UintptrStr": "0",
-				"StrStr": "\"\\u0008\\u000c\\n\\r\\t\\\"\\\\\"",
-				"NumberStr": "0"
-			}`,
+		want: `{
+	"BoolStr": "true",
+	"IntStr": "42",
+	"UintptrStr": "44",
+	"StrStr": "\"xzbit\"",
+	"NumberStr": "46"
+}`,
+	}, {
+		// See golang.org/issues/38173.
+		CaseName: Name("StringDoubleEscapes"),
+		in: StringTag{
+			StrStr:    "\b\f\n\r\t\"\\",
+			NumberStr: "0", // just to satisfy the roundtrip
 		},
-	}
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			// Indent with a tab prefix to make the multi-line string
-			// literals in the table nicer to read.
-			got, err := MarshalIndent(&test.in, "\t\t\t", "\t")
+		want: `{
+	"BoolStr": "false",
+	"IntStr": "0",
+	"UintptrStr": "0",
+	"StrStr": "\"\\b\\f\\n\\r\\t\\\"\\\\\"",
+	"NumberStr": "0"
+}`,
+	}}
+	for _, tt := range tests {
+		t.Run(tt.Name, func(t *testing.T) {
+			got, err := MarshalIndent(&tt.in, "", "\t")
 			if err != nil {
-				t.Fatal(err)
+				t.Fatalf("%s: MarshalIndent error: %v", tt.Where, err)
 			}
-			if got := string(got); got != test.want {
-				t.Fatalf(" got: %s\nwant: %s\n", got, test.want)
+			if got := string(got); got != tt.want {
+				t.Fatalf("%s: MarshalIndent:\n\tgot:  %s\n\twant: %s", tt.Where, stripWhitespace(got), stripWhitespace(tt.want))
 			}
 
 			// Verify that it round-trips.
 			var s2 StringTag
 			if err := Unmarshal(got, &s2); err != nil {
-				t.Fatalf("Decode: %v", err)
+				t.Fatalf("%s: Decode error: %v", tt.Where, err)
 			}
-			if !reflect.DeepEqual(test.in, s2) {
-				t.Fatalf("decode didn't match.\nsource: %#v\nEncoded as:\n%s\ndecode: %#v", test.in, string(got), s2)
+			if !reflect.DeepEqual(s2, tt.in) {
+				t.Fatalf("%s: Decode:\n\tinput: %s\n\tgot:  %#v\n\twant: %#v", tt.Where, indentNewlines(string(got)), s2, tt.in)
 			}
 		})
 	}
@@ -149,21 +143,21 @@ type renamedRenamedByteSlice []renamedByte
 
 func TestEncodeRenamedByteSlice(t *testing.T) {
 	s := renamedByteSlice("abc")
-	result, err := Marshal(s)
+	got, err := Marshal(s)
 	if err != nil {
-		t.Fatal(err)
+		t.Fatalf("Marshal error: %v", err)
 	}
-	expect := `"YWJj"`
-	if string(result) != expect {
-		t.Errorf(" got %s want %s", result, expect)
+	want := `"YWJj"`
+	if string(got) != want {
+		t.Errorf("Marshal:\n\tgot:  %s\n\twant: %s", got, want)
 	}
 	r := renamedRenamedByteSlice("abc")
-	result, err = Marshal(r)
+	got, err = Marshal(r)
 	if err != nil {
-		t.Fatal(err)
+		t.Fatalf("Marshal error: %v", err)
 	}
-	if string(result) != expect {
-		t.Errorf(" got %s want %s", result, expect)
+	if string(got) != want {
+		t.Errorf("Marshal:\n\tgot:  %s\n\twant: %s", got, want)
 	}
 }
 
@@ -212,36 +206,40 @@ func init() {
 
 func TestSamePointerNoCycle(t *testing.T) {
 	if _, err := Marshal(samePointerNoCycle); err != nil {
-		t.Fatalf("unexpected error: %v", err)
+		t.Fatalf("Marshal error: %v", err)
 	}
 }
 
 func TestSliceNoCycle(t *testing.T) {
 	if _, err := Marshal(sliceNoCycle); err != nil {
-		t.Fatalf("unexpected error: %v", err)
+		t.Fatalf("Marshal error: %v", err)
 	}
 }
 
-var unsupportedValues = []any{
-	math.NaN(),
-	math.Inf(-1),
-	math.Inf(1),
-	pointerCycle,
-	pointerCycleIndirect,
-	mapCycle,
-	sliceCycle,
-	recursiveSliceCycle,
-}
-
 func TestUnsupportedValues(t *testing.T) {
-	for _, v := range unsupportedValues {
-		if _, err := Marshal(v); err != nil {
-			if _, ok := err.(*UnsupportedValueError); !ok {
-				t.Errorf("for %v, got %T want UnsupportedValueError", v, err)
+	tests := []struct {
+		CaseName
+		in any
+	}{
+		{Name(""), math.NaN()},
+		{Name(""), math.Inf(-1)},
+		{Name(""), math.Inf(1)},
+		{Name(""), pointerCycle},
+		{Name(""), pointerCycleIndirect},
+		{Name(""), mapCycle},
+		{Name(""), sliceCycle},
+		{Name(""), recursiveSliceCycle},
+	}
+	for _, tt := range tests {
+		t.Run(tt.Name, func(t *testing.T) {
+			if _, err := Marshal(tt.in); err != nil {
+				if _, ok := err.(*UnsupportedValueError); !ok {
+					t.Errorf("%s: Marshal error:\n\tgot:  %T\n\twant: %T", tt.Where, err, new(UnsupportedValueError))
+				}
+			} else {
+				t.Errorf("%s: Marshal error: got nil, want non-nil", tt.Where)
 			}
-		} else {
-			t.Errorf("for %v, expected error", v)
-		}
+		})
 	}
 }
 
@@ -253,11 +251,11 @@ func TestMarshalTextFloatMap(t *testing.T) {
 	}
 	got, err := Marshal(m)
 	if err != nil {
-		t.Errorf("Marshal() error: %v", err)
+		t.Errorf("Marshal error: %v", err)
 	}
 	want := `{"TF:NaN":"1","TF:NaN":"1"}`
 	if string(got) != want {
-		t.Errorf("Marshal() = %s, want %s", got, want)
+		t.Errorf("Marshal:\n\tgot:  %s\n\twant: %s", got, want)
 	}
 }
 
@@ -322,10 +320,10 @@ func TestRefValMarshal(t *testing.T) {
 	const want = `{"R0":"ref","R1":"ref","R2":"\"ref\"","R3":"\"ref\"","V0":"val","V1":"val","V2":"\"val\"","V3":"\"val\""}`
 	b, err := Marshal(&s)
 	if err != nil {
-		t.Fatalf("Marshal: %v", err)
+		t.Fatalf("Marshal error: %v", err)
 	}
 	if got := string(b); got != want {
-		t.Errorf("got %q, want %q", got, want)
+		t.Errorf("Marshal:\n\tgot:  %s\n\twant: %s", got, want)
 	}
 }
 
@@ -348,33 +346,33 @@ func TestMarshalerEscaping(t *testing.T) {
 	want := `"\u003c\u0026\u003e"`
 	b, err := Marshal(c)
 	if err != nil {
-		t.Fatalf("Marshal(c): %v", err)
+		t.Fatalf("Marshal error: %v", err)
 	}
 	if got := string(b); got != want {
-		t.Errorf("Marshal(c) = %#q, want %#q", got, want)
+		t.Errorf("Marshal:\n\tgot:  %s\n\twant: %s", got, want)
 	}
 
 	var ct CText
 	want = `"\"\u003c\u0026\u003e\""`
 	b, err = Marshal(ct)
 	if err != nil {
-		t.Fatalf("Marshal(ct): %v", err)
+		t.Fatalf("Marshal error: %v", err)
 	}
 	if got := string(b); got != want {
-		t.Errorf("Marshal(ct) = %#q, want %#q", got, want)
+		t.Errorf("Marshal:\n\tgot:  %s\n\twant: %s", got, want)
 	}
 }
 
 func TestAnonymousFields(t *testing.T) {
 	tests := []struct {
-		label     string     // Test name
+		CaseName
 		makeInput func() any // Function to create input value
 		want      string     // Expected JSON output
 	}{{
 		// Both S1 and S2 have a field named X. From the perspective of S,
 		// it is ambiguous which one X refers to.
 		// This should not serialize either field.
-		label: "AmbiguousField",
+		CaseName: Name("AmbiguousField"),
 		makeInput: func() any {
 			type (
 				S1 struct{ x, X int }
@@ -388,7 +386,7 @@ func TestAnonymousFields(t *testing.T) {
 		},
 		want: `{}`,
 	}, {
-		label: "DominantField",
+		CaseName: Name("DominantField"),
 		// Both S1 and S2 have a field named X, but since S has an X field as
 		// well, it takes precedence over S1.X and S2.X.
 		makeInput: func() any {
@@ -406,7 +404,7 @@ func TestAnonymousFields(t *testing.T) {
 		want: `{"X":6}`,
 	}, {
 		// Unexported embedded field of non-struct type should not be serialized.
-		label: "UnexportedEmbeddedInt",
+		CaseName: Name("UnexportedEmbeddedInt"),
 		makeInput: func() any {
 			type (
 				myInt int
@@ -417,7 +415,7 @@ func TestAnonymousFields(t *testing.T) {
 		want: `{}`,
 	}, {
 		// Exported embedded field of non-struct type should be serialized.
-		label: "ExportedEmbeddedInt",
+		CaseName: Name("ExportedEmbeddedInt"),
 		makeInput: func() any {
 			type (
 				MyInt int
@@ -429,7 +427,7 @@ func TestAnonymousFields(t *testing.T) {
 	}, {
 		// Unexported embedded field of pointer to non-struct type
 		// should not be serialized.
-		label: "UnexportedEmbeddedIntPointer",
+		CaseName: Name("UnexportedEmbeddedIntPointer"),
 		makeInput: func() any {
 			type (
 				myInt int
@@ -443,7 +441,7 @@ func TestAnonymousFields(t *testing.T) {
 	}, {
 		// Exported embedded field of pointer to non-struct type
 		// should be serialized.
-		label: "ExportedEmbeddedIntPointer",
+		CaseName: Name("ExportedEmbeddedIntPointer"),
 		makeInput: func() any {
 			type (
 				MyInt int
@@ -458,7 +456,7 @@ func TestAnonymousFields(t *testing.T) {
 		// Exported fields of embedded structs should have their
 		// exported fields be serialized regardless of whether the struct types
 		// themselves are exported.
-		label: "EmbeddedStruct",
+		CaseName: Name("EmbeddedStruct"),
 		makeInput: func() any {
 			type (
 				s1 struct{ x, X int }
@@ -475,7 +473,7 @@ func TestAnonymousFields(t *testing.T) {
 		// Exported fields of pointers to embedded structs should have their
 		// exported fields be serialized regardless of whether the struct types
 		// themselves are exported.
-		label: "EmbeddedStructPointer",
+		CaseName: Name("EmbeddedStructPointer"),
 		makeInput: func() any {
 			type (
 				s1 struct{ x, X int }
@@ -491,7 +489,7 @@ func TestAnonymousFields(t *testing.T) {
 	}, {
 		// Exported fields on embedded unexported structs at multiple levels
 		// of nesting should still be serialized.
-		label: "NestedStructAndInts",
+		CaseName: Name("NestedStructAndInts"),
 		makeInput: func() any {
 			type (
 				MyInt1 int
@@ -518,7 +516,7 @@ func TestAnonymousFields(t *testing.T) {
 		// If an anonymous struct pointer field is nil, we should ignore
 		// the embedded fields behind it. Not properly doing so may
 		// result in the wrong output or reflect panics.
-		label: "EmbeddedFieldBehindNilPointer",
+		CaseName: Name("EmbeddedFieldBehindNilPointer"),
 		makeInput: func() any {
 			type (
 				S2 struct{ Field string }
@@ -530,13 +528,13 @@ func TestAnonymousFields(t *testing.T) {
 	}}
 
 	for _, tt := range tests {
-		t.Run(tt.label, func(t *testing.T) {
+		t.Run(tt.Name, func(t *testing.T) {
 			b, err := Marshal(tt.makeInput())
 			if err != nil {
-				t.Fatalf("Marshal() = %v, want nil error", err)
+				t.Fatalf("%s: Marshal error: %v", tt.Where, err)
 			}
 			if string(b) != tt.want {
-				t.Fatalf("Marshal() = %q, want %q", b, tt.want)
+				t.Fatalf("%s: Marshal:\n\tgot:  %s\n\twant: %s", tt.Where, b, tt.want)
 			}
 		})
 	}
@@ -588,31 +586,34 @@ func (nm *nilTextMarshaler) MarshalText() ([]byte, error) {
 
 // See golang.org/issue/16042 and golang.org/issue/34235.
 func TestNilMarshal(t *testing.T) {
-	testCases := []struct {
-		v    any
+	tests := []struct {
+		CaseName
+		in   any
 		want string
 	}{
-		{v: nil, want: `null`},
-		{v: new(float64), want: `0`},
-		{v: []any(nil), want: `null`},
-		{v: []string(nil), want: `null`},
-		{v: map[string]string(nil), want: `null`},
-		{v: []byte(nil), want: `null`},
-		{v: struct{ M string }{"gopher"}, want: `{"M":"gopher"}`},
-		{v: struct{ M Marshaler }{}, want: `{"M":null}`},
-		{v: struct{ M Marshaler }{(*nilJSONMarshaler)(nil)}, want: `{"M":"0zenil0"}`},
-		{v: struct{ M any }{(*nilJSONMarshaler)(nil)}, want: `{"M":null}`},
-		{v: struct{ M encoding.TextMarshaler }{}, want: `{"M":null}`},
-		{v: struct{ M encoding.TextMarshaler }{(*nilTextMarshaler)(nil)}, want: `{"M":"0zenil0"}`},
-		{v: struct{ M any }{(*nilTextMarshaler)(nil)}, want: `{"M":null}`},
+		{Name(""), nil, `null`},
+		{Name(""), new(float64), `0`},
+		{Name(""), []any(nil), `null`},
+		{Name(""), []string(nil), `null`},
+		{Name(""), map[string]string(nil), `null`},
+		{Name(""), []byte(nil), `null`},
+		{Name(""), struct{ M string }{"gopher"}, `{"M":"gopher"}`},
+		{Name(""), struct{ M Marshaler }{}, `{"M":null}`},
+		{Name(""), struct{ M Marshaler }{(*nilJSONMarshaler)(nil)}, `{"M":"0zenil0"}`},
+		{Name(""), struct{ M any }{(*nilJSONMarshaler)(nil)}, `{"M":null}`},
+		{Name(""), struct{ M encoding.TextMarshaler }{}, `{"M":null}`},
+		{Name(""), struct{ M encoding.TextMarshaler }{(*nilTextMarshaler)(nil)}, `{"M":"0zenil0"}`},
+		{Name(""), struct{ M any }{(*nilTextMarshaler)(nil)}, `{"M":null}`},
 	}
-
-	for _, tt := range testCases {
-		out, err := Marshal(tt.v)
-		if err != nil || string(out) != tt.want {
-			t.Errorf("Marshal(%#v) = %#q, %#v, want %#q, nil", tt.v, out, err, tt.want)
-			continue
-		}
+	for _, tt := range tests {
+		t.Run(tt.Name, func(t *testing.T) {
+			switch got, err := Marshal(tt.in); {
+			case err != nil:
+				t.Fatalf("%s: Marshal error: %v", tt.Where, err)
+			case string(got) != tt.want:
+				t.Fatalf("%s: Marshal:\n\tgot:  %s\n\twant: %s", tt.Where, got, tt.want)
+			}
+		})
 	}
 }
 
@@ -624,12 +625,12 @@ func TestEmbeddedBug(t *testing.T) {
 	}
 	b, err := Marshal(v)
 	if err != nil {
-		t.Fatal("Marshal:", err)
+		t.Fatal("Marshal error:", err)
 	}
 	want := `{"S":"B"}`
 	got := string(b)
 	if got != want {
-		t.Fatalf("Marshal: got %s want %s", got, want)
+		t.Fatalf("Marshal:\n\tgot:  %s\n\twant: %s", got, want)
 	}
 	// Now check that the duplicate field, S, does not appear.
 	x := BugX{
@@ -637,12 +638,12 @@ func TestEmbeddedBug(t *testing.T) {
 	}
 	b, err = Marshal(x)
 	if err != nil {
-		t.Fatal("Marshal:", err)
+		t.Fatal("Marshal error:", err)
 	}
 	want = `{"A":23}`
 	got = string(b)
 	if got != want {
-		t.Fatalf("Marshal: got %s want %s", got, want)
+		t.Fatalf("Marshal:\n\tgot:  %s\n\twant: %s", got, want)
 	}
 }
 
@@ -664,12 +665,12 @@ func TestTaggedFieldDominates(t *testing.T) {
 	}
 	b, err := Marshal(v)
 	if err != nil {
-		t.Fatal("Marshal:", err)
+		t.Fatal("Marshal error:", err)
 	}
 	want := `{"S":"BugD"}`
 	got := string(b)
 	if got != want {
-		t.Fatalf("Marshal: got %s want %s", got, want)
+		t.Fatalf("Marshal:\n\tgot:  %s\n\twant: %s", got, want)
 	}
 }
 
@@ -691,60 +692,12 @@ func TestDuplicatedFieldDisappears(t *testing.T) {
 	}
 	b, err := Marshal(v)
 	if err != nil {
-		t.Fatal("Marshal:", err)
+		t.Fatal("Marshal error:", err)
 	}
 	want := `{}`
 	got := string(b)
 	if got != want {
-		t.Fatalf("Marshal: got %s want %s", got, want)
-	}
-}
-
-func TestStringBytes(t *testing.T) {
-	t.Parallel()
-	// Test that encodeState.stringBytes and encodeState.string use the same encoding.
-	var r []rune
-	for i := '\u0000'; i <= unicode.MaxRune; i++ {
-		if testing.Short() && i > 1000 {
-			i = unicode.MaxRune
-		}
-		r = append(r, i)
-	}
-	s := string(r) + "\xff\xff\xffhello" // some invalid UTF-8 too
-
-	for _, escapeHTML := range []bool{true, false} {
-		es := &encodeState{}
-		es.string(s, escapeHTML)
-
-		esBytes := &encodeState{}
-		esBytes.stringBytes([]byte(s), escapeHTML)
-
-		enc := es.Buffer.String()
-		encBytes := esBytes.Buffer.String()
-		if enc != encBytes {
-			i := 0
-			for i < len(enc) && i < len(encBytes) && enc[i] == encBytes[i] {
-				i++
-			}
-			enc = enc[i:]
-			encBytes = encBytes[i:]
-			i = 0
-			for i < len(enc) && i < len(encBytes) && enc[len(enc)-i-1] == encBytes[len(encBytes)-i-1] {
-				i++
-			}
-			enc = enc[:len(enc)-i]
-			encBytes = encBytes[:len(encBytes)-i]
-
-			if len(enc) > 20 {
-				enc = enc[:20] + "..."
-			}
-			if len(encBytes) > 20 {
-				encBytes = encBytes[:20] + "..."
-			}
-
-			t.Errorf("with escapeHTML=%t, encodings differ at %#q vs %#q",
-				escapeHTML, enc, encBytes)
-		}
+		t.Fatalf("Marshal:\n\tgot:  %s\n\twant: %s", got, want)
 	}
 }
 
@@ -754,9 +707,43 @@ func TestIssue10281(t *testing.T) {
 	}
 	x := Foo{Number(`invalid`)}
 
-	b, err := Marshal(&x)
-	if err == nil {
-		t.Errorf("Marshal(&x) = %#q; want error", b)
+	if _, err := Marshal(&x); err == nil {
+		t.Fatalf("Marshal error: got nil, want non-nil")
+	}
+}
+
+func TestMarshalErrorAndReuseEncodeState(t *testing.T) {
+	// Disable the GC temporarily to prevent encodeState's in Pool being cleaned away during the test.
+	percent := debug.SetGCPercent(-1)
+	defer debug.SetGCPercent(percent)
+
+	// Trigger an error in Marshal with cyclic data.
+	type Dummy struct {
+		Name string
+		Next *Dummy
+	}
+	dummy := Dummy{Name: "Dummy"}
+	dummy.Next = &dummy
+	if _, err := Marshal(dummy); err == nil {
+		t.Errorf("Marshal error: got nil, want non-nil")
+	}
+
+	type Data struct {
+		A string
+		I int
+	}
+	want := Data{A: "a", I: 1}
+	b, err := Marshal(want)
+	if err != nil {
+		t.Errorf("Marshal error: %v", err)
+	}
+
+	var got Data
+	if err := Unmarshal(b, &got); err != nil {
+		t.Errorf("Unmarshal error: %v", err)
+	}
+	if got != want {
+		t.Errorf("Unmarshal:\n\tgot:  %v\n\twant: %v", got, want)
 	}
 }
 
@@ -766,7 +753,7 @@ func TestHTMLEscape(t *testing.T) {
 	want.Write([]byte(`{"M":"\u003chtml\u003efoo \u0026\u2028 \u2029\u003c/html\u003e"}`))
 	HTMLEscape(&b, []byte(m))
 	if !bytes.Equal(b.Bytes(), want.Bytes()) {
-		t.Errorf("HTMLEscape(&b, []byte(m)) = %s; want %s", b.Bytes(), want.Bytes())
+		t.Errorf("HTMLEscape:\n\tgot:  %s\n\twant: %s", b.Bytes(), want.Bytes())
 	}
 }
 
@@ -778,21 +765,19 @@ func TestEncodePointerString(t *testing.T) {
 	var n int64 = 42
 	b, err := Marshal(stringPointer{N: &n})
 	if err != nil {
-		t.Fatalf("Marshal: %v", err)
+		t.Fatalf("Marshal error: %v", err)
 	}
 	if got, want := string(b), `{"n":"42"}`; got != want {
-		t.Errorf("Marshal = %s, want %s", got, want)
+		t.Fatalf("Marshal:\n\tgot:  %s\n\twant: %s", got, want)
 	}
 	var back stringPointer
-	err = Unmarshal(b, &back)
-	if err != nil {
-		t.Fatalf("Unmarshal: %v", err)
-	}
-	if back.N == nil {
-		t.Fatalf("Unmarshaled nil N field")
-	}
-	if *back.N != 42 {
-		t.Fatalf("*N = %d; want 42", *back.N)
+	switch err = Unmarshal(b, &back); {
+	case err != nil:
+		t.Fatalf("Unmarshal error: %v", err)
+	case back.N == nil:
+		t.Fatalf("Unmarshal: back.N = nil, want non-nil")
+	case *back.N != 42:
+		t.Fatalf("Unmarshal: *back.N = %d, want 42", *back.N)
 	}
 }
 
@@ -808,11 +793,11 @@ var encodeStringTests = []struct {
 	{"\x05", `"\u0005"`},
 	{"\x06", `"\u0006"`},
 	{"\x07", `"\u0007"`},
-	{"\x08", `"\u0008"`},
+	{"\x08", `"\b"`},
 	{"\x09", `"\t"`},
 	{"\x0a", `"\n"`},
 	{"\x0b", `"\u000b"`},
-	{"\x0c", `"\u000c"`},
+	{"\x0c", `"\f"`},
 	{"\x0d", `"\r"`},
 	{"\x0e", `"\u000e"`},
 	{"\x0f", `"\u000f"`},
@@ -838,7 +823,7 @@ func TestEncodeString(t *testing.T) {
 	for _, tt := range encodeStringTests {
 		b, err := Marshal(tt.in)
 		if err != nil {
-			t.Errorf("Marshal(%q): %v", tt.in, err)
+			t.Errorf("Marshal(%q) error: %v", tt.in, err)
 			continue
 		}
 		out := string(b)
@@ -876,65 +861,67 @@ func (f textfloat) MarshalText() ([]byte, error) { return tenc(`TF:%0.2f`, f) }
 
 // Issue 13783
 func TestEncodeBytekind(t *testing.T) {
-	testdata := []struct {
-		data any
+	tests := []struct {
+		CaseName
+		in   any
 		want string
 	}{
-		{byte(7), "7"},
-		{jsonbyte(7), `{"JB":7}`},
-		{textbyte(4), `"TB:4"`},
-		{jsonint(5), `{"JI":5}`},
-		{textint(1), `"TI:1"`},
-		{[]byte{0, 1}, `"AAE="`},
-		{[]jsonbyte{0, 1}, `[{"JB":0},{"JB":1}]`},
-		{[][]jsonbyte{{0, 1}, {3}}, `[[{"JB":0},{"JB":1}],[{"JB":3}]]`},
-		{[]textbyte{2, 3}, `["TB:2","TB:3"]`},
-		{[]jsonint{5, 4}, `[{"JI":5},{"JI":4}]`},
-		{[]textint{9, 3}, `["TI:9","TI:3"]`},
-		{[]int{9, 3}, `[9,3]`},
-		{[]textfloat{12, 3}, `["TF:12.00","TF:3.00"]`},
+		{Name(""), byte(7), "7"},
+		{Name(""), jsonbyte(7), `{"JB":7}`},
+		{Name(""), textbyte(4), `"TB:4"`},
+		{Name(""), jsonint(5), `{"JI":5}`},
+		{Name(""), textint(1), `"TI:1"`},
+		{Name(""), []byte{0, 1}, `"AAE="`},
+		{Name(""), []jsonbyte{0, 1}, `[{"JB":0},{"JB":1}]`},
+		{Name(""), [][]jsonbyte{{0, 1}, {3}}, `[[{"JB":0},{"JB":1}],[{"JB":3}]]`},
+		{Name(""), []textbyte{2, 3}, `["TB:2","TB:3"]`},
+		{Name(""), []jsonint{5, 4}, `[{"JI":5},{"JI":4}]`},
+		{Name(""), []textint{9, 3}, `["TI:9","TI:3"]`},
+		{Name(""), []int{9, 3}, `[9,3]`},
+		{Name(""), []textfloat{12, 3}, `["TF:12.00","TF:3.00"]`},
 	}
-	for _, d := range testdata {
-		js, err := Marshal(d.data)
-		if err != nil {
-			t.Error(err)
-			continue
-		}
-		got, want := string(js), d.want
-		if got != want {
-			t.Errorf("got %s, want %s", got, want)
-		}
+	for _, tt := range tests {
+		t.Run(tt.Name, func(t *testing.T) {
+			b, err := Marshal(tt.in)
+			if err != nil {
+				t.Errorf("%s: Marshal error: %v", tt.Where, err)
+			}
+			got, want := string(b), tt.want
+			if got != want {
+				t.Errorf("%s: Marshal:\n\tgot:  %s\n\twant: %s", tt.Where, got, want)
+			}
+		})
 	}
 }
 
 func TestTextMarshalerMapKeysAreSorted(t *testing.T) {
-	b, err := Marshal(map[unmarshalerText]int{
+	got, err := Marshal(map[unmarshalerText]int{
 		{"x", "y"}: 1,
 		{"y", "x"}: 2,
 		{"a", "z"}: 3,
 		{"z", "a"}: 4,
 	})
 	if err != nil {
-		t.Fatalf("Failed to Marshal text.Marshaler: %v", err)
+		t.Fatalf("Marshal error: %v", err)
 	}
 	const want = `{"a:z":3,"x:y":1,"y:x":2,"z:a":4}`
-	if string(b) != want {
-		t.Errorf("Marshal map with text.Marshaler keys: got %#q, want %#q", b, want)
+	if string(got) != want {
+		t.Errorf("Marshal:\n\tgot:  %s\n\twant: %s", got, want)
 	}
 }
 
 // https://golang.org/issue/33675
 func TestNilMarshalerTextMapKey(t *testing.T) {
-	b, err := Marshal(map[*unmarshalerText]int{
+	got, err := Marshal(map[*unmarshalerText]int{
 		(*unmarshalerText)(nil): 1,
 		{"A", "B"}:              2,
 	})
 	if err != nil {
-		t.Fatalf("Failed to Marshal *text.Marshaler: %v", err)
+		t.Fatalf("Marshal error: %v", err)
 	}
 	const want = `{"":1,"A:B":2}`
-	if string(b) != want {
-		t.Errorf("Marshal map with *text.Marshaler keys: got %#q, want %#q", b, want)
+	if string(got) != want {
+		t.Errorf("Marshal:\n\tgot:  %s\n\twant: %s", got, want)
 	}
 }
 
@@ -973,7 +960,7 @@ func TestMarshalFloat(t *testing.T) {
 		}
 		bout, err := Marshal(vf)
 		if err != nil {
-			t.Errorf("Marshal(%T(%g)): %v", vf, vf, err)
+			t.Errorf("Marshal(%T(%g)) error: %v", vf, vf, err)
 			nfail++
 			return
 		}
@@ -982,12 +969,12 @@ func TestMarshalFloat(t *testing.T) {
 		// result must convert back to the same float
 		g, err := strconv.ParseFloat(out, bits)
 		if err != nil {
-			t.Errorf("Marshal(%T(%g)) = %q, cannot parse back: %v", vf, vf, out, err)
+			t.Errorf("ParseFloat(%q) error: %v", out, err)
 			nfail++
 			return
 		}
 		if f != g || fmt.Sprint(f) != fmt.Sprint(g) { // fmt.Sprint handles ±0
-			t.Errorf("Marshal(%T(%g)) = %q (is %g, not %g)", vf, vf, out, float32(g), vf)
+			t.Errorf("ParseFloat(%q):\n\tgot:  %g\n\twant: %g", out, float32(g), vf)
 			nfail++
 			return
 		}
@@ -998,7 +985,7 @@ func TestMarshalFloat(t *testing.T) {
 		}
 		for _, re := range bad {
 			if re.MatchString(out) {
-				t.Errorf("Marshal(%T(%g)) = %q, must not match /%s/", vf, vf, out, re)
+				t.Errorf("Marshal(%T(%g)) = %q; must not match /%s/", vf, vf, out, re)
 				nfail++
 				return
 			}
@@ -1062,87 +1049,90 @@ func TestMarshalRawMessageValue(t *testing.T) {
 	)
 
 	tests := []struct {
+		CaseName
 		in   any
 		want string
 		ok   bool
 	}{
 		// Test with nil RawMessage.
-		{rawNil, "null", true},
-		{&rawNil, "null", true},
-		{[]any{rawNil}, "[null]", true},
-		{&[]any{rawNil}, "[null]", true},
-		{[]any{&rawNil}, "[null]", true},
-		{&[]any{&rawNil}, "[null]", true},
-		{struct{ M RawMessage }{rawNil}, `{"M":null}`, true},
-		{&struct{ M RawMessage }{rawNil}, `{"M":null}`, true},
-		{struct{ M *RawMessage }{&rawNil}, `{"M":null}`, true},
-		{&struct{ M *RawMessage }{&rawNil}, `{"M":null}`, true},
-		{map[string]any{"M": rawNil}, `{"M":null}`, true},
-		{&map[string]any{"M": rawNil}, `{"M":null}`, true},
-		{map[string]any{"M": &rawNil}, `{"M":null}`, true},
-		{&map[string]any{"M": &rawNil}, `{"M":null}`, true},
-		{T1{rawNil}, "{}", true},
-		{T2{&rawNil}, `{"M":null}`, true},
-		{&T1{rawNil}, "{}", true},
-		{&T2{&rawNil}, `{"M":null}`, true},
+		{Name(""), rawNil, "null", true},
+		{Name(""), &rawNil, "null", true},
+		{Name(""), []any{rawNil}, "[null]", true},
+		{Name(""), &[]any{rawNil}, "[null]", true},
+		{Name(""), []any{&rawNil}, "[null]", true},
+		{Name(""), &[]any{&rawNil}, "[null]", true},
+		{Name(""), struct{ M RawMessage }{rawNil}, `{"M":null}`, true},
+		{Name(""), &struct{ M RawMessage }{rawNil}, `{"M":null}`, true},
+		{Name(""), struct{ M *RawMessage }{&rawNil}, `{"M":null}`, true},
+		{Name(""), &struct{ M *RawMessage }{&rawNil}, `{"M":null}`, true},
+		{Name(""), map[string]any{"M": rawNil}, `{"M":null}`, true},
+		{Name(""), &map[string]any{"M": rawNil}, `{"M":null}`, true},
+		{Name(""), map[string]any{"M": &rawNil}, `{"M":null}`, true},
+		{Name(""), &map[string]any{"M": &rawNil}, `{"M":null}`, true},
+		{Name(""), T1{rawNil}, "{}", true},
+		{Name(""), T2{&rawNil}, `{"M":null}`, true},
+		{Name(""), &T1{rawNil}, "{}", true},
+		{Name(""), &T2{&rawNil}, `{"M":null}`, true},
 
 		// Test with empty, but non-nil, RawMessage.
-		{rawEmpty, "", false},
-		{&rawEmpty, "", false},
-		{[]any{rawEmpty}, "", false},
-		{&[]any{rawEmpty}, "", false},
-		{[]any{&rawEmpty}, "", false},
-		{&[]any{&rawEmpty}, "", false},
-		{struct{ X RawMessage }{rawEmpty}, "", false},
-		{&struct{ X RawMessage }{rawEmpty}, "", false},
-		{struct{ X *RawMessage }{&rawEmpty}, "", false},
-		{&struct{ X *RawMessage }{&rawEmpty}, "", false},
-		{map[string]any{"nil": rawEmpty}, "", false},
-		{&map[string]any{"nil": rawEmpty}, "", false},
-		{map[string]any{"nil": &rawEmpty}, "", false},
-		{&map[string]any{"nil": &rawEmpty}, "", false},
-		{T1{rawEmpty}, "{}", true},
-		{T2{&rawEmpty}, "", false},
-		{&T1{rawEmpty}, "{}", true},
-		{&T2{&rawEmpty}, "", false},
+		{Name(""), rawEmpty, "", false},
+		{Name(""), &rawEmpty, "", false},
+		{Name(""), []any{rawEmpty}, "", false},
+		{Name(""), &[]any{rawEmpty}, "", false},
+		{Name(""), []any{&rawEmpty}, "", false},
+		{Name(""), &[]any{&rawEmpty}, "", false},
+		{Name(""), struct{ X RawMessage }{rawEmpty}, "", false},
+		{Name(""), &struct{ X RawMessage }{rawEmpty}, "", false},
+		{Name(""), struct{ X *RawMessage }{&rawEmpty}, "", false},
+		{Name(""), &struct{ X *RawMessage }{&rawEmpty}, "", false},
+		{Name(""), map[string]any{"nil": rawEmpty}, "", false},
+		{Name(""), &map[string]any{"nil": rawEmpty}, "", false},
+		{Name(""), map[string]any{"nil": &rawEmpty}, "", false},
+		{Name(""), &map[string]any{"nil": &rawEmpty}, "", false},
+		{Name(""), T1{rawEmpty}, "{}", true},
+		{Name(""), T2{&rawEmpty}, "", false},
+		{Name(""), &T1{rawEmpty}, "{}", true},
+		{Name(""), &T2{&rawEmpty}, "", false},
 
 		// Test with RawMessage with some text.
 		//
 		// The tests below marked with Issue6458 used to generate "ImZvbyI=" instead "foo".
 		// This behavior was intentionally changed in Go 1.8.
 		// See https://golang.org/issues/14493#issuecomment-255857318
-		{rawText, `"foo"`, true}, // Issue6458
-		{&rawText, `"foo"`, true},
-		{[]any{rawText}, `["foo"]`, true},  // Issue6458
-		{&[]any{rawText}, `["foo"]`, true}, // Issue6458
-		{[]any{&rawText}, `["foo"]`, true},
-		{&[]any{&rawText}, `["foo"]`, true},
-		{struct{ M RawMessage }{rawText}, `{"M":"foo"}`, true}, // Issue6458
-		{&struct{ M RawMessage }{rawText}, `{"M":"foo"}`, true},
-		{struct{ M *RawMessage }{&rawText}, `{"M":"foo"}`, true},
-		{&struct{ M *RawMessage }{&rawText}, `{"M":"foo"}`, true},
-		{map[string]any{"M": rawText}, `{"M":"foo"}`, true},  // Issue6458
-		{&map[string]any{"M": rawText}, `{"M":"foo"}`, true}, // Issue6458
-		{map[string]any{"M": &rawText}, `{"M":"foo"}`, true},
-		{&map[string]any{"M": &rawText}, `{"M":"foo"}`, true},
-		{T1{rawText}, `{"M":"foo"}`, true}, // Issue6458
-		{T2{&rawText}, `{"M":"foo"}`, true},
-		{&T1{rawText}, `{"M":"foo"}`, true},
-		{&T2{&rawText}, `{"M":"foo"}`, true},
+		{Name(""), rawText, `"foo"`, true}, // Issue6458
+		{Name(""), &rawText, `"foo"`, true},
+		{Name(""), []any{rawText}, `["foo"]`, true},  // Issue6458
+		{Name(""), &[]any{rawText}, `["foo"]`, true}, // Issue6458
+		{Name(""), []any{&rawText}, `["foo"]`, true},
+		{Name(""), &[]any{&rawText}, `["foo"]`, true},
+		{Name(""), struct{ M RawMessage }{rawText}, `{"M":"foo"}`, true}, // Issue6458
+		{Name(""), &struct{ M RawMessage }{rawText}, `{"M":"foo"}`, true},
+		{Name(""), struct{ M *RawMessage }{&rawText}, `{"M":"foo"}`, true},
+		{Name(""), &struct{ M *RawMessage }{&rawText}, `{"M":"foo"}`, true},
+		{Name(""), map[string]any{"M": rawText}, `{"M":"foo"}`, true},  // Issue6458
+		{Name(""), &map[string]any{"M": rawText}, `{"M":"foo"}`, true}, // Issue6458
+		{Name(""), map[string]any{"M": &rawText}, `{"M":"foo"}`, true},
+		{Name(""), &map[string]any{"M": &rawText}, `{"M":"foo"}`, true},
+		{Name(""), T1{rawText}, `{"M":"foo"}`, true}, // Issue6458
+		{Name(""), T2{&rawText}, `{"M":"foo"}`, true},
+		{Name(""), &T1{rawText}, `{"M":"foo"}`, true},
+		{Name(""), &T2{&rawText}, `{"M":"foo"}`, true},
 	}
 
-	for i, tt := range tests {
-		b, err := Marshal(tt.in)
-		if ok := (err == nil); ok != tt.ok {
-			if err != nil {
-				t.Errorf("test %d, unexpected failure: %v", i, err)
-			} else {
-				t.Errorf("test %d, unexpected success", i)
+	for _, tt := range tests {
+		t.Run(tt.Name, func(t *testing.T) {
+			b, err := Marshal(tt.in)
+			if ok := (err == nil); ok != tt.ok {
+				if err != nil {
+					t.Errorf("%s: Marshal error: %v", tt.Where, err)
+				} else {
+					t.Errorf("%s: Marshal error: got nil, want non-nil", tt.Where)
+				}
 			}
-		}
-		if got := string(b); got != tt.want {
-			t.Errorf("test %d, Marshal(%#v) = %q, want %q", i, tt.in, got, tt.want)
-		}
+			if got := string(b); got != tt.want {
+				t.Errorf("%s: Marshal:\n\tinput: %#v\n\tgot:  %s\n\twant: %s", tt.Where, tt.in, got, tt.want)
+			}
+		})
 	}
 }
 
@@ -1166,38 +1156,66 @@ func TestMarshalUncommonFieldNames(t *testing.T) {
 	}{}
 	b, err := Marshal(v)
 	if err != nil {
-		t.Fatal("Marshal:", err)
+		t.Fatal("Marshal error:", err)
 	}
 	want := `{"A0":0,"À":0,"Aβ":0}`
 	got := string(b)
 	if got != want {
-		t.Fatalf("Marshal: got %s want %s", got, want)
+		t.Fatalf("Marshal:\n\tgot:  %s\n\twant: %s", got, want)
 	}
 }
 
 func TestMarshalerError(t *testing.T) {
 	s := "test variable"
 	st := reflect.TypeOf(s)
-	errText := "json: test error"
+	const errText = "json: test error"
 
 	tests := []struct {
+		CaseName
 		err  *MarshalerError
 		want string
-	}{
-		{
-			&MarshalerError{st, fmt.Errorf(errText), ""},
-			"json: error calling MarshalJSON for type " + st.String() + ": " + errText,
-		},
-		{
-			&MarshalerError{st, fmt.Errorf(errText), "TestMarshalerError"},
-			"json: error calling TestMarshalerError for type " + st.String() + ": " + errText,
-		},
-	}
+	}{{
+		Name(""),
+		&MarshalerError{st, fmt.Errorf(errText), ""},
+		"json: error calling MarshalJSON for type " + st.String() + ": " + errText,
+	}, {
+		Name(""),
+		&MarshalerError{st, fmt.Errorf(errText), "TestMarshalerError"},
+		"json: error calling TestMarshalerError for type " + st.String() + ": " + errText,
+	}}
 
-	for i, tt := range tests {
-		got := tt.err.Error()
-		if got != tt.want {
-			t.Errorf("MarshalerError test %d, got: %s, want: %s", i, got, tt.want)
+	for _, tt := range tests {
+		t.Run(tt.Name, func(t *testing.T) {
+			got := tt.err.Error()
+			if got != tt.want {
+				t.Errorf("%s: Error:\n\tgot:  %s\n\twant: %s", tt.Where, got, tt.want)
+			}
+		})
+	}
+}
+
+type marshaledValue string
+
+func (v marshaledValue) MarshalJSON() ([]byte, error) {
+	return []byte(v), nil
+}
+
+func TestIssue63379(t *testing.T) {
+	for _, v := range []string{
+		"[]<",
+		"[]>",
+		"[]&",
+		"[]\u2028",
+		"[]\u2029",
+		"{}<",
+		"{}>",
+		"{}&",
+		"{}\u2028",
+		"{}\u2029",
+	} {
+		_, err := Marshal(marshaledValue(v))
+		if err == nil {
+			t.Errorf("expected error for %q", v)
 		}
 	}
 }

--- a/internal/golang/encoding/json/fold.go
+++ b/internal/golang/encoding/json/fold.go
@@ -5,140 +5,44 @@
 package json
 
 import (
-	"bytes"
+	"unicode"
 	"unicode/utf8"
 )
 
-const (
-	caseMask     = ^byte(0x20) // Mask to ignore case in ASCII.
-	kelvin       = '\u212a'
-	smallLongEss = '\u017f'
-)
-
-// foldFunc returns one of four different case folding equivalence
-// functions, from most general (and slow) to fastest:
-//
-// 1) bytes.EqualFold, if the key s contains any non-ASCII UTF-8
-// 2) equalFoldRight, if s contains special folding ASCII ('k', 'K', 's', 'S')
-// 3) asciiEqualFold, no special, but includes non-letters (including _)
-// 4) simpleLetterEqualFold, no specials, no non-letters.
-//
-// The letters S and K are special because they map to 3 runes, not just 2:
-//   - S maps to s and to U+017F 'ſ' Latin small letter long s
-//   - k maps to K and to U+212A 'K' Kelvin sign
-//
-// See https://play.golang.org/p/tTxjOc0OGo
-//
-// The returned function is specialized for matching against s and
-// should only be given s. It's not curried for performance reasons.
-func foldFunc(s []byte) func(s, t []byte) bool {
-	nonLetter := false
-	special := false // special letter
-	for _, b := range s {
-		if b >= utf8.RuneSelf {
-			return bytes.EqualFold
-		}
-		upper := b & caseMask
-		if upper < 'A' || upper > 'Z' {
-			nonLetter = true
-		} else if upper == 'K' || upper == 'S' {
-			// See above for why these letters are special.
-			special = true
-		}
-	}
-	if special {
-		return equalFoldRight
-	}
-	if nonLetter {
-		return asciiEqualFold
-	}
-	return simpleLetterEqualFold
+// foldName returns a folded string such that foldName(x) == foldName(y)
+// is identical to bytes.EqualFold(x, y).
+func foldName(in []byte) []byte {
+	// This is inlinable to take advantage of "function outlining".
+	var arr [32]byte // large enough for most JSON names
+	return appendFoldedName(arr[:0], in)
 }
 
-// equalFoldRight is a specialization of bytes.EqualFold when s is
-// known to be all ASCII (including punctuation), but contains an 's',
-// 'S', 'k', or 'K', requiring a Unicode fold on the bytes in t.
-// See comments on foldFunc.
-func equalFoldRight(s, t []byte) bool {
-	for _, sb := range s {
-		if len(t) == 0 {
-			return false
-		}
-		tb := t[0]
-		if tb < utf8.RuneSelf {
-			if sb != tb {
-				sbUpper := sb & caseMask
-				if 'A' <= sbUpper && sbUpper <= 'Z' {
-					if sbUpper != tb&caseMask {
-						return false
-					}
-				} else {
-					return false
-				}
+func appendFoldedName(out, in []byte) []byte {
+	for i := 0; i < len(in); {
+		// Handle single-byte ASCII.
+		if c := in[i]; c < utf8.RuneSelf {
+			if 'a' <= c && c <= 'z' {
+				c -= 'a' - 'A'
 			}
-			t = t[1:]
+			out = append(out, c)
+			i++
 			continue
 		}
-		// sb is ASCII and t is not. t must be either kelvin
-		// sign or long s; sb must be s, S, k, or K.
-		tr, size := utf8.DecodeRune(t)
-		switch sb {
-		case 's', 'S':
-			if tr != smallLongEss {
-				return false
-			}
-		case 'k', 'K':
-			if tr != kelvin {
-				return false
-			}
-		default:
-			return false
-		}
-		t = t[size:]
-
+		// Handle multi-byte Unicode.
+		r, n := utf8.DecodeRune(in[i:])
+		out = utf8.AppendRune(out, foldRune(r))
+		i += n
 	}
-	if len(t) > 0 {
-		return false
-	}
-	return true
+	return out
 }
 
-// asciiEqualFold is a specialization of bytes.EqualFold for use when
-// s is all ASCII (but may contain non-letters) and contains no
-// special-folding letters.
-// See comments on foldFunc.
-func asciiEqualFold(s, t []byte) bool {
-	if len(s) != len(t) {
-		return false
-	}
-	for i, sb := range s {
-		tb := t[i]
-		if sb == tb {
-			continue
+// foldRune is returns the smallest rune for all runes in the same fold set.
+func foldRune(r rune) rune {
+	for {
+		r2 := unicode.SimpleFold(r)
+		if r2 <= r {
+			return r2
 		}
-		if ('a' <= sb && sb <= 'z') || ('A' <= sb && sb <= 'Z') {
-			if sb&caseMask != tb&caseMask {
-				return false
-			}
-		} else {
-			return false
-		}
+		r = r2
 	}
-	return true
-}
-
-// simpleLetterEqualFold is a specialization of bytes.EqualFold for
-// use when s is all ASCII letters (no underscores, etc) and also
-// doesn't contain 'k', 'K', 's', or 'S'.
-// See comments on foldFunc.
-func simpleLetterEqualFold(s, t []byte) bool {
-	if len(s) != len(t) {
-		return false
-	}
-	for i, b := range s {
-		if b&caseMask != t[i]&caseMask {
-			return false
-		}
-	}
-	return true
 }

--- a/internal/golang/encoding/json/fold_test.go
+++ b/internal/golang/encoding/json/fold_test.go
@@ -6,111 +6,45 @@ package json
 
 import (
 	"bytes"
-	"strings"
 	"testing"
-	"unicode/utf8"
 )
 
-var foldTests = []struct {
-	fn   func(s, t []byte) bool
-	s, t string
-	want bool
-}{
-	{equalFoldRight, "", "", true},
-	{equalFoldRight, "a", "a", true},
-	{equalFoldRight, "", "a", false},
-	{equalFoldRight, "a", "", false},
-	{equalFoldRight, "a", "A", true},
-	{equalFoldRight, "AB", "ab", true},
-	{equalFoldRight, "AB", "ac", false},
-	{equalFoldRight, "sbkKc", "ſbKKc", true},
-	{equalFoldRight, "SbKkc", "ſbKKc", true},
-	{equalFoldRight, "SbKkc", "ſbKK", false},
-	{equalFoldRight, "e", "é", false},
-	{equalFoldRight, "s", "S", true},
-
-	{simpleLetterEqualFold, "", "", true},
-	{simpleLetterEqualFold, "abc", "abc", true},
-	{simpleLetterEqualFold, "abc", "ABC", true},
-	{simpleLetterEqualFold, "abc", "ABCD", false},
-	{simpleLetterEqualFold, "abc", "xxx", false},
-
-	{asciiEqualFold, "a_B", "A_b", true},
-	{asciiEqualFold, "aa@", "aa`", false}, // verify 0x40 and 0x60 aren't case-equivalent
-}
-
-func TestFold(t *testing.T) {
-	for i, tt := range foldTests {
-		if got := tt.fn([]byte(tt.s), []byte(tt.t)); got != tt.want {
-			t.Errorf("%d. %q, %q = %v; want %v", i, tt.s, tt.t, got, tt.want)
+func FuzzEqualFold(f *testing.F) {
+	for _, ss := range [][2]string{
+		{"", ""},
+		{"123abc", "123ABC"},
+		{"αβδ", "ΑΒΔ"},
+		{"abc", "xyz"},
+		{"abc", "XYZ"},
+		{"1", "2"},
+		{"hello, world!", "hello, world!"},
+		{"hello, world!", "Hello, World!"},
+		{"hello, world!", "HELLO, WORLD!"},
+		{"hello, world!", "jello, world!"},
+		{"γειά, κόσμε!", "γειά, κόσμε!"},
+		{"γειά, κόσμε!", "Γειά, Κόσμε!"},
+		{"γειά, κόσμε!", "ΓΕΙΆ, ΚΌΣΜΕ!"},
+		{"γειά, κόσμε!", "ΛΕΙΆ, ΚΌΣΜΕ!"},
+		{"AESKey", "aesKey"},
+		{"AESKEY", "aes_key"},
+		{"aes_key", "AES_KEY"},
+		{"AES_KEY", "aes-key"},
+		{"aes-key", "AES-KEY"},
+		{"AES-KEY", "aesKey"},
+		{"aesKey", "AesKey"},
+		{"AesKey", "AESKey"},
+		{"AESKey", "aeskey"},
+		{"DESKey", "aeskey"},
+		{"AES Key", "aeskey"},
+	} {
+		f.Add([]byte(ss[0]), []byte(ss[1]))
+	}
+	equalFold := func(x, y []byte) bool { return string(foldName(x)) == string(foldName(y)) }
+	f.Fuzz(func(t *testing.T, x, y []byte) {
+		got := equalFold(x, y)
+		want := bytes.EqualFold(x, y)
+		if got != want {
+			t.Errorf("equalFold(%q, %q) = %v, want %v", x, y, got, want)
 		}
-		truth := strings.EqualFold(tt.s, tt.t)
-		if truth != tt.want {
-			t.Errorf("strings.EqualFold doesn't agree with case %d", i)
-		}
-	}
-}
-
-func TestFoldAgainstUnicode(t *testing.T) {
-	const bufSize = 5
-	buf1 := make([]byte, 0, bufSize)
-	buf2 := make([]byte, 0, bufSize)
-	var runes []rune
-	for i := 0x20; i <= 0x7f; i++ {
-		runes = append(runes, rune(i))
-	}
-	runes = append(runes, kelvin, smallLongEss)
-
-	funcs := []struct {
-		name   string
-		fold   func(s, t []byte) bool
-		letter bool // must be ASCII letter
-		simple bool // must be simple ASCII letter (not 'S' or 'K')
-	}{
-		{
-			name: "equalFoldRight",
-			fold: equalFoldRight,
-		},
-		{
-			name:   "asciiEqualFold",
-			fold:   asciiEqualFold,
-			simple: true,
-		},
-		{
-			name:   "simpleLetterEqualFold",
-			fold:   simpleLetterEqualFold,
-			simple: true,
-			letter: true,
-		},
-	}
-
-	for _, ff := range funcs {
-		for _, r := range runes {
-			if r >= utf8.RuneSelf {
-				continue
-			}
-			if ff.letter && !isASCIILetter(byte(r)) {
-				continue
-			}
-			if ff.simple && (r == 's' || r == 'S' || r == 'k' || r == 'K') {
-				continue
-			}
-			for _, r2 := range runes {
-				buf1 := append(buf1[:0], 'x')
-				buf2 := append(buf2[:0], 'x')
-				buf1 = buf1[:1+utf8.EncodeRune(buf1[1:bufSize], r)]
-				buf2 = buf2[:1+utf8.EncodeRune(buf2[1:bufSize], r2)]
-				buf1 = append(buf1, 'x')
-				buf2 = append(buf2, 'x')
-				want := bytes.EqualFold(buf1, buf2)
-				if got := ff.fold(buf1, buf2); got != want {
-					t.Errorf("%s(%q, %q) = %v; want %v", ff.name, buf1, buf2, got, want)
-				}
-			}
-		}
-	}
-}
-
-func isASCIILetter(b byte) bool {
-	return ('A' <= b && b <= 'Z') || ('a' <= b && b <= 'z')
+	})
 }

--- a/internal/golang/encoding/json/indent.go
+++ b/internal/golang/encoding/json/indent.go
@@ -4,38 +4,67 @@
 
 package json
 
-import (
-	"bytes"
-)
+import "bytes"
+
+// HTMLEscape appends to dst the JSON-encoded src with <, >, &, U+2028 and U+2029
+// characters inside string literals changed to \u003c, \u003e, \u0026, \u2028, \u2029
+// so that the JSON will be safe to embed inside HTML <script> tags.
+// For historical reasons, web browsers don't honor standard HTML
+// escaping within <script> tags, so an alternative JSON encoding must be used.
+func HTMLEscape(dst *bytes.Buffer, src []byte) {
+	dst.Grow(len(src))
+	dst.Write(appendHTMLEscape(dst.AvailableBuffer(), src))
+}
+
+func appendHTMLEscape(dst, src []byte) []byte {
+	// The characters can only appear in string literals,
+	// so just scan the string one byte at a time.
+	start := 0
+	for i, c := range src {
+		if c == '<' || c == '>' || c == '&' {
+			dst = append(dst, src[start:i]...)
+			dst = append(dst, '\\', 'u', '0', '0', hex[c>>4], hex[c&0xF])
+			start = i + 1
+		}
+		// Convert U+2028 and U+2029 (E2 80 A8 and E2 80 A9).
+		if c == 0xE2 && i+2 < len(src) && src[i+1] == 0x80 && src[i+2]&^1 == 0xA8 {
+			dst = append(dst, src[start:i]...)
+			dst = append(dst, '\\', 'u', '2', '0', '2', hex[src[i+2]&0xF])
+			start = i + len("\u2029")
+		}
+	}
+	return append(dst, src[start:]...)
+}
 
 // Compact appends to dst the JSON-encoded src with
 // insignificant space characters elided.
 func Compact(dst *bytes.Buffer, src []byte) error {
-	return compact(dst, src, false)
+	dst.Grow(len(src))
+	b := dst.AvailableBuffer()
+	b, err := appendCompact(b, src, false)
+	dst.Write(b)
+	return err
 }
 
-func compact(dst *bytes.Buffer, src []byte, escape bool) error {
-	origLen := dst.Len()
+func appendCompact(dst, src []byte, escape bool) ([]byte, error) {
+	origLen := len(dst)
 	scan := newScanner()
 	defer freeScanner(scan)
 	start := 0
 	for i, c := range src {
 		if escape && (c == '<' || c == '>' || c == '&') {
 			if start < i {
-				dst.Write(src[start:i])
+				dst = append(dst, src[start:i]...)
 			}
-			dst.WriteString(`\u00`)
-			dst.WriteByte(hex[c>>4])
-			dst.WriteByte(hex[c&0xF])
+			dst = append(dst, '\\', 'u', '0', '0', hex[c>>4], hex[c&0xF])
 			start = i + 1
 		}
 		// Convert U+2028 and U+2029 (E2 80 A8 and E2 80 A9).
 		if escape && c == 0xE2 && i+2 < len(src) && src[i+1] == 0x80 && src[i+2]&^1 == 0xA8 {
 			if start < i {
-				dst.Write(src[start:i])
+				dst = append(dst, src[start:i]...)
 			}
-			dst.WriteString(`\u202`)
-			dst.WriteByte(hex[src[i+2]&0xF])
+			dst = append(dst, '\\', 'u', '2', '0', '2', hex[src[i+2]&0xF])
 			start = i + 3
 		}
 		v := scan.step(scan, c)
@@ -44,28 +73,36 @@ func compact(dst *bytes.Buffer, src []byte, escape bool) error {
 				break
 			}
 			if start < i {
-				dst.Write(src[start:i])
+				dst = append(dst, src[start:i]...)
 			}
 			start = i + 1
 		}
 	}
 	if scan.eof() == scanError {
-		dst.Truncate(origLen)
-		return scan.err
+		return dst[:origLen], scan.err
 	}
 	if start < len(src) {
-		dst.Write(src[start:])
+		dst = append(dst, src[start:]...)
 	}
-	return nil
+	return dst, nil
 }
 
-func newline(dst *bytes.Buffer, prefix, indent string, depth int) {
-	dst.WriteByte('\n')
-	dst.WriteString(prefix)
+func appendNewline(dst []byte, prefix, indent string, depth int) []byte {
+	dst = append(dst, '\n')
+	dst = append(dst, prefix...)
 	for i := 0; i < depth; i++ {
-		dst.WriteString(indent)
+		dst = append(dst, indent...)
 	}
+	return dst
 }
+
+// indentGrowthFactor specifies the growth factor of indenting JSON input.
+// Empirically, the growth factor was measured to be between 1.4x to 1.8x
+// for some set of compacted JSON with the indent being a single tab.
+// Specify a growth factor slightly larger than what is observed
+// to reduce probability of allocation in appendIndent.
+// A factor no higher than 2 ensures that wasted space never exceeds 50%.
+const indentGrowthFactor = 2
 
 // Indent appends to dst an indented form of the JSON-encoded src.
 // Each element in a JSON object or array begins on a new,
@@ -79,7 +116,15 @@ func newline(dst *bytes.Buffer, prefix, indent string, depth int) {
 // For example, if src has no trailing spaces, neither will dst;
 // if src ends in a trailing newline, so will dst.
 func Indent(dst *bytes.Buffer, src []byte, prefix, indent string) error {
-	origLen := dst.Len()
+	dst.Grow(indentGrowthFactor * len(src))
+	b := dst.AvailableBuffer()
+	b, err := appendIndent(b, src, prefix, indent)
+	dst.Write(b)
+	return err
+}
+
+func appendIndent(dst, src []byte, prefix, indent string) ([]byte, error) {
+	origLen := len(dst)
 	scan := newScanner()
 	defer freeScanner(scan)
 	needIndent := false
@@ -96,13 +141,13 @@ func Indent(dst *bytes.Buffer, src []byte, prefix, indent string) error {
 		if needIndent && v != scanEndObject && v != scanEndArray {
 			needIndent = false
 			depth++
-			newline(dst, prefix, indent, depth)
+			dst = appendNewline(dst, prefix, indent, depth)
 		}
 
 		// Emit semantically uninteresting bytes
 		// (in particular, punctuation in strings) unmodified.
 		if v == scanContinue {
-			dst.WriteByte(c)
+			dst = append(dst, c)
 			continue
 		}
 
@@ -111,33 +156,27 @@ func Indent(dst *bytes.Buffer, src []byte, prefix, indent string) error {
 		case '{', '[':
 			// delay indent so that empty object and array are formatted as {} and [].
 			needIndent = true
-			dst.WriteByte(c)
-
+			dst = append(dst, c)
 		case ',':
-			dst.WriteByte(c)
-			newline(dst, prefix, indent, depth)
-
+			dst = append(dst, c)
+			dst = appendNewline(dst, prefix, indent, depth)
 		case ':':
-			dst.WriteByte(c)
-			dst.WriteByte(' ')
-
+			dst = append(dst, c, ' ')
 		case '}', ']':
 			if needIndent {
 				// suppress indent in empty object/array
 				needIndent = false
 			} else {
 				depth--
-				newline(dst, prefix, indent, depth)
+				dst = appendNewline(dst, prefix, indent, depth)
 			}
-			dst.WriteByte(c)
-
+			dst = append(dst, c)
 		default:
-			dst.WriteByte(c)
+			dst = append(dst, c)
 		}
 	}
 	if scan.eof() == scanError {
-		dst.Truncate(origLen)
-		return scan.err
+		return dst[:origLen], scan.err
 	}
-	return nil
+	return dst, nil
 }

--- a/internal/golang/encoding/json/number_test.go
+++ b/internal/golang/encoding/json/number_test.go
@@ -116,18 +116,3 @@ func TestNumberIsValid(t *testing.T) {
 		}
 	}
 }
-
-func BenchmarkNumberIsValid(b *testing.B) {
-	s := "-61657.61667E+61673"
-	for i := 0; i < b.N; i++ {
-		isValidNumber(s)
-	}
-}
-
-func BenchmarkNumberIsValidRegexp(b *testing.B) {
-	var jsonNumberRegexp = regexp.MustCompile(`^-?(?:0|[1-9]\d*)(?:\.\d+)?(?:[eE][+-]?\d+)?$`)
-	s := "-61657.61667E+61673"
-	for i := 0; i < b.N; i++ {
-		jsonNumberRegexp.MatchString(s)
-	}
-}

--- a/internal/golang/encoding/json/scanner.go
+++ b/internal/golang/encoding/json/scanner.go
@@ -43,7 +43,7 @@ func checkValid(data []byte, scan *scanner) error {
 }
 
 // A SyntaxError is a description of a JSON syntax error.
-// Unmarshal will return a SyntaxError if the JSON can't be parsed.
+// [Unmarshal] will return a SyntaxError if the JSON can't be parsed.
 type SyntaxError struct {
 	msg    string // description of error
 	Offset int64  // error occurred after reading Offset bytes
@@ -594,7 +594,7 @@ func (s *scanner) error(c byte, context string) int {
 	return scanError
 }
 
-// quoteChar formats c as a quoted character literal
+// quoteChar formats c as a quoted character literal.
 func quoteChar(c byte) string {
 	// special cases - different from quoted strings
 	if c == '\'' {

--- a/internal/golang/encoding/json/stream.go
+++ b/internal/golang/encoding/json/stream.go
@@ -6,7 +6,6 @@ package json
 
 import (
 	"bytes"
-	"errors"
 	"io"
 )
 
@@ -253,6 +252,7 @@ func (enc *Encoder) SetEscapeHTML(on bool) {
 	enc.escapeHTML = on
 }
 
+/*
 // RawMessage is a raw encoded JSON value.
 // It implements [Marshaler] and [Unmarshaler] and can
 // be used to delay JSON decoding or precompute a JSON encoding.
@@ -274,10 +274,12 @@ func (m *RawMessage) UnmarshalJSON(data []byte) error {
 	*m = append((*m)[0:0], data...)
 	return nil
 }
+*/
 
 var _ Marshaler = (*RawMessage)(nil)
 var _ Unmarshaler = (*RawMessage)(nil)
 
+/*
 // A Token holds a value of one of these types:
 //
 //   - [Delim], for the four JSON delimiters [ ] { }
@@ -287,6 +289,7 @@ var _ Unmarshaler = (*RawMessage)(nil)
 //   - string, for JSON string literals
 //   - nil, for JSON null
 type Token any
+*/
 
 const (
 	tokenTopValue = iota
@@ -347,12 +350,14 @@ func (dec *Decoder) tokenValueEnd() {
 	}
 }
 
+/*
 // A Delim is a JSON array or object delimiter, one of [ ] { or }.
 type Delim rune
 
 func (d Delim) String() string {
 	return string(d)
 }
+*/
 
 // Token returns the next JSON token in the input stream.
 // At the end of the input stream, Token returns nil, [io.EOF].

--- a/internal/golang/encoding/json/stream.go
+++ b/internal/golang/encoding/json/stream.go
@@ -6,6 +6,7 @@ package json
 
 import (
 	"bytes"
+	"errors"
 	"io"
 )
 
@@ -32,7 +33,7 @@ func NewDecoder(r io.Reader) *Decoder {
 }
 
 // UseNumber causes the Decoder to unmarshal a number into an interface{} as a
-// Number instead of as a float64.
+// [Number] instead of as a float64.
 func (dec *Decoder) UseNumber() { dec.d.useNumber = true }
 
 // DisallowUnknownFields causes the Decoder to return an error when the destination
@@ -43,7 +44,7 @@ func (dec *Decoder) DisallowUnknownFields() { dec.d.disallowUnknownFields = true
 // Decode reads the next JSON-encoded value from its
 // input and stores it in the value pointed to by v.
 //
-// See the documentation for Unmarshal for details about
+// See the documentation for [Unmarshal] for details about
 // the conversion of JSON into a Go value.
 func (dec *Decoder) Decode(v any) error {
 	if dec.err != nil {
@@ -78,7 +79,7 @@ func (dec *Decoder) Decode(v any) error {
 }
 
 // Buffered returns a reader of the data remaining in the Decoder's
-// buffer. The reader is valid until the next call to Decode.
+// buffer. The reader is valid until the next call to [Decoder.Decode].
 func (dec *Decoder) Buffered() io.Reader {
 	return bytes.NewReader(dec.buf[dec.scanp:])
 }
@@ -182,7 +183,7 @@ type Encoder struct {
 	err        error
 	escapeHTML bool
 
-	indentBuf    *bytes.Buffer
+	indentBuf    []byte
 	indentPrefix string
 	indentValue  string
 }
@@ -193,15 +194,19 @@ func NewEncoder(w io.Writer) *Encoder {
 }
 
 // Encode writes the JSON encoding of v to the stream,
+// with insignificant space characters elided,
 // followed by a newline character.
 //
-// See the documentation for Marshal for details about the
+// See the documentation for [Marshal] for details about the
 // conversion of Go values to JSON.
 func (enc *Encoder) Encode(v any) error {
 	if enc.err != nil {
 		return enc.err
 	}
+
 	e := newEncodeState()
+	defer encodeStatePool.Put(e)
+
 	err := e.marshal(v, encOpts{escapeHTML: enc.escapeHTML})
 	if err != nil {
 		return err
@@ -217,20 +222,15 @@ func (enc *Encoder) Encode(v any) error {
 
 	b := e.Bytes()
 	if enc.indentPrefix != "" || enc.indentValue != "" {
-		if enc.indentBuf == nil {
-			enc.indentBuf = new(bytes.Buffer)
-		}
-		enc.indentBuf.Reset()
-		err = Indent(enc.indentBuf, b, enc.indentPrefix, enc.indentValue)
+		enc.indentBuf, err = appendIndent(enc.indentBuf[:0], b, enc.indentPrefix, enc.indentValue)
 		if err != nil {
 			return err
 		}
-		b = enc.indentBuf.Bytes()
+		b = enc.indentBuf
 	}
 	if _, err = enc.w.Write(b); err != nil {
 		enc.err = err
 	}
-	encodeStatePool.Put(e)
 	return err
 }
 
@@ -253,9 +253,8 @@ func (enc *Encoder) SetEscapeHTML(on bool) {
 	enc.escapeHTML = on
 }
 
-/*
 // RawMessage is a raw encoded JSON value.
-// It implements Marshaler and Unmarshaler and can
+// It implements [Marshaler] and [Unmarshaler] and can
 // be used to delay JSON decoding or precompute a JSON encoding.
 type RawMessage []byte
 
@@ -275,22 +274,19 @@ func (m *RawMessage) UnmarshalJSON(data []byte) error {
 	*m = append((*m)[0:0], data...)
 	return nil
 }
-*/
 
 var _ Marshaler = (*RawMessage)(nil)
 var _ Unmarshaler = (*RawMessage)(nil)
 
-/*
 // A Token holds a value of one of these types:
 //
-//	Delim, for the four JSON delimiters [ ] { }
-//	bool, for JSON booleans
-//	float64, for JSON numbers
-//	Number, for JSON numbers
-//	string, for JSON string literals
-//	nil, for JSON null
+//   - [Delim], for the four JSON delimiters [ ] { }
+//   - bool, for JSON booleans
+//   - float64, for JSON numbers
+//   - [Number], for JSON numbers
+//   - string, for JSON string literals
+//   - nil, for JSON null
 type Token any
-*/
 
 const (
 	tokenTopValue = iota
@@ -351,24 +347,22 @@ func (dec *Decoder) tokenValueEnd() {
 	}
 }
 
-/*
 // A Delim is a JSON array or object delimiter, one of [ ] { or }.
 type Delim rune
 
 func (d Delim) String() string {
 	return string(d)
 }
-*/
 
 // Token returns the next JSON token in the input stream.
-// At the end of the input stream, Token returns nil, io.EOF.
+// At the end of the input stream, Token returns nil, [io.EOF].
 //
 // Token guarantees that the delimiters [ ] { } it returns are
 // properly nested and matched: if Token encounters an unexpected
 // delimiter in the input, it will return an error.
 //
 // The input stream consists of basic JSON values—bool, string,
-// number, and null—along with delimiters [ ] { } of type Delim
+// number, and null—along with delimiters [ ] { } of type [Delim]
 // to mark the start and end of arrays and objects.
 // Commas and colons are elided.
 func (dec *Decoder) Token() (Token, error) {

--- a/internal/golang/encoding/json/stream_test.go
+++ b/internal/golang/encoding/json/stream_test.go
@@ -6,15 +6,43 @@ package json
 
 import (
 	"bytes"
+	"fmt"
 	"io"
 	"log"
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"path"
 	"reflect"
+	"runtime"
+	"runtime/debug"
 	"strings"
 	"testing"
 )
+
+// TODO(https://go.dev/issue/52751): Replace with native testing support.
+
+// CaseName is a case name annotated with a file and line.
+type CaseName struct {
+	Name  string
+	Where CasePos
+}
+
+// Name annotates a case name with the file and line of the caller.
+func Name(s string) (c CaseName) {
+	c.Name = s
+	runtime.Callers(2, c.Where.pc[:])
+	return c
+}
+
+// CasePos represents a file and line number.
+type CasePos struct{ pc [1]uintptr }
+
+func (pos CasePos) String() string {
+	frames := runtime.CallersFrames(pos.pc[:])
+	frame, _ := frames.Next()
+	return fmt.Sprintf("%s:%d", path.Base(frame.File), frame.Line)
+}
 
 // Test values for the stream test.
 // One of each JSON kind.
@@ -41,21 +69,58 @@ false
 
 func TestEncoder(t *testing.T) {
 	for i := 0; i <= len(streamTest); i++ {
-		var buf bytes.Buffer
+		var buf strings.Builder
 		enc := NewEncoder(&buf)
 		// Check that enc.SetIndent("", "") turns off indentation.
 		enc.SetIndent(">", ".")
 		enc.SetIndent("", "")
 		for j, v := range streamTest[0:i] {
 			if err := enc.Encode(v); err != nil {
-				t.Fatalf("encode #%d: %v", j, err)
+				t.Fatalf("#%d.%d Encode error: %v", i, j, err)
 			}
 		}
 		if have, want := buf.String(), nlines(streamEncoded, i); have != want {
-			t.Errorf("encoding %d items: mismatch", i)
+			t.Errorf("encoding %d items: mismatch:", i)
 			diff(t, []byte(have), []byte(want))
 			break
 		}
+	}
+}
+
+func TestEncoderErrorAndReuseEncodeState(t *testing.T) {
+	// Disable the GC temporarily to prevent encodeState's in Pool being cleaned away during the test.
+	percent := debug.SetGCPercent(-1)
+	defer debug.SetGCPercent(percent)
+
+	// Trigger an error in Marshal with cyclic data.
+	type Dummy struct {
+		Name string
+		Next *Dummy
+	}
+	dummy := Dummy{Name: "Dummy"}
+	dummy.Next = &dummy
+
+	var buf bytes.Buffer
+	enc := NewEncoder(&buf)
+	if err := enc.Encode(dummy); err == nil {
+		t.Errorf("Encode(dummy) error: got nil, want non-nil")
+	}
+
+	type Data struct {
+		A string
+		I int
+	}
+	want := Data{A: "a", I: 1}
+	if err := enc.Encode(want); err != nil {
+		t.Errorf("Marshal error: %v", err)
+	}
+
+	var got Data
+	if err := Unmarshal(buf.Bytes(), &got); err != nil {
+		t.Errorf("Unmarshal error: %v", err)
+	}
+	if got != want {
+		t.Errorf("Marshal/Unmarshal roundtrip:\n\tgot:  %v\n\twant: %v", got, want)
 	}
 }
 
@@ -77,14 +142,14 @@ false
 `
 
 func TestEncoderIndent(t *testing.T) {
-	var buf bytes.Buffer
+	var buf strings.Builder
 	enc := NewEncoder(&buf)
 	enc.SetIndent(">", ".")
 	for _, v := range streamTest {
 		enc.Encode(v)
 	}
 	if have, want := buf.String(), streamEncodedIndent; have != want {
-		t.Error("indented encoding mismatch")
+		t.Error("Encode mismatch:")
 		diff(t, []byte(have), []byte(want))
 	}
 }
@@ -122,50 +187,51 @@ func TestEncoderSetEscapeHTML(t *testing.T) {
 		Bar string `json:"bar,string"`
 	}{`<html>foobar</html>`}
 
-	for _, tt := range []struct {
-		name       string
+	tests := []struct {
+		CaseName
 		v          any
 		wantEscape string
 		want       string
 	}{
-		{"c", c, `"\u003c\u0026\u003e"`, `"<&>"`},
-		{"ct", ct, `"\"\u003c\u0026\u003e\""`, `"\"<&>\""`},
-		{`"<&>"`, "<&>", `"\u003c\u0026\u003e"`, `"<&>"`},
+		{Name("c"), c, `"\u003c\u0026\u003e"`, `"<&>"`},
+		{Name("ct"), ct, `"\"\u003c\u0026\u003e\""`, `"\"<&>\""`},
+		{Name(`"<&>"`), "<&>", `"\u003c\u0026\u003e"`, `"<&>"`},
 		{
-			"tagStruct", tagStruct,
+			Name("tagStruct"), tagStruct,
 			`{"\u003c\u003e\u0026#! ":0,"Invalid":0}`,
 			`{"<>&#! ":0,"Invalid":0}`,
 		},
 		{
-			`"<str>"`, marshalerStruct,
+			Name(`"<str>"`), marshalerStruct,
 			`{"NonPtr":"\u003cstr\u003e","Ptr":"\u003cstr\u003e"}`,
 			`{"NonPtr":"<str>","Ptr":"<str>"}`,
 		},
 		{
-			"stringOption", stringOption,
+			Name("stringOption"), stringOption,
 			`{"bar":"\"\\u003chtml\\u003efoobar\\u003c/html\\u003e\""}`,
 			`{"bar":"\"<html>foobar</html>\""}`,
 		},
-	} {
-		var buf bytes.Buffer
-		enc := NewEncoder(&buf)
-		if err := enc.Encode(tt.v); err != nil {
-			t.Errorf("Encode(%s): %s", tt.name, err)
-			continue
-		}
-		if got := strings.TrimSpace(buf.String()); got != tt.wantEscape {
-			t.Errorf("Encode(%s) = %#q, want %#q", tt.name, got, tt.wantEscape)
-		}
-		buf.Reset()
-		enc.SetEscapeHTML(false)
-		if err := enc.Encode(tt.v); err != nil {
-			t.Errorf("SetEscapeHTML(false) Encode(%s): %s", tt.name, err)
-			continue
-		}
-		if got := strings.TrimSpace(buf.String()); got != tt.want {
-			t.Errorf("SetEscapeHTML(false) Encode(%s) = %#q, want %#q",
-				tt.name, got, tt.want)
-		}
+	}
+	for _, tt := range tests {
+		t.Run(tt.Name, func(t *testing.T) {
+			var buf strings.Builder
+			enc := NewEncoder(&buf)
+			if err := enc.Encode(tt.v); err != nil {
+				t.Fatalf("%s: Encode(%s) error: %s", tt.Where, tt.Name, err)
+			}
+			if got := strings.TrimSpace(buf.String()); got != tt.wantEscape {
+				t.Errorf("%s: Encode(%s):\n\tgot:  %s\n\twant: %s", tt.Where, tt.Name, got, tt.wantEscape)
+			}
+			buf.Reset()
+			enc.SetEscapeHTML(false)
+			if err := enc.Encode(tt.v); err != nil {
+				t.Fatalf("%s: SetEscapeHTML(false) Encode(%s) error: %s", tt.Where, tt.Name, err)
+			}
+			if got := strings.TrimSpace(buf.String()); got != tt.want {
+				t.Errorf("%s: SetEscapeHTML(false) Encode(%s):\n\tgot:  %s\n\twant: %s",
+					tt.Where, tt.Name, got, tt.want)
+			}
+		})
 	}
 }
 
@@ -186,14 +252,14 @@ func TestDecoder(t *testing.T) {
 		dec := NewDecoder(&buf)
 		for j := range out {
 			if err := dec.Decode(&out[j]); err != nil {
-				t.Fatalf("decode #%d/%d: %v", j, i, err)
+				t.Fatalf("decode #%d/%d error: %v", j, i, err)
 			}
 		}
 		if !reflect.DeepEqual(out, streamTest[0:i]) {
-			t.Errorf("decoding %d items: mismatch", i)
+			t.Errorf("decoding %d items: mismatch:", i)
 			for j := range out {
 				if !reflect.DeepEqual(out[j], streamTest[j]) {
-					t.Errorf("#%d: have %v want %v", j, out[j], streamTest[j])
+					t.Errorf("#%d:\n\tgot:  %v\n\twant: %v", j, out[j], streamTest[j])
 				}
 			}
 			break
@@ -212,14 +278,14 @@ func TestDecoderBuffered(t *testing.T) {
 		t.Fatal(err)
 	}
 	if m.Name != "Gopher" {
-		t.Errorf("Name = %q; want Gopher", m.Name)
+		t.Errorf("Name = %s, want Gopher", m.Name)
 	}
 	rest, err := io.ReadAll(d.Buffered())
 	if err != nil {
 		t.Fatal(err)
 	}
-	if g, w := string(rest), " extra "; g != w {
-		t.Errorf("Remaining = %q; want %q", g, w)
+	if got, want := string(rest), " extra "; got != want {
+		t.Errorf("Remaining = %s, want %s", got, want)
 	}
 }
 
@@ -244,20 +310,20 @@ func TestRawMessage(t *testing.T) {
 		Y  float32
 	}
 	const raw = `["\u0056",null]`
-	const msg = `{"X":0.1,"Id":["\u0056",null],"Y":0.2}`
-	err := Unmarshal([]byte(msg), &data)
+	const want = `{"X":0.1,"Id":["\u0056",null],"Y":0.2}`
+	err := Unmarshal([]byte(want), &data)
 	if err != nil {
-		t.Fatalf("Unmarshal: %v", err)
+		t.Fatalf("Unmarshal error: %v", err)
 	}
 	if string([]byte(data.Id)) != raw {
-		t.Fatalf("Raw mismatch: have %#q want %#q", []byte(data.Id), raw)
+		t.Fatalf("Unmarshal:\n\tgot:  %s\n\twant: %s", []byte(data.Id), raw)
 	}
-	b, err := Marshal(&data)
+	got, err := Marshal(&data)
 	if err != nil {
-		t.Fatalf("Marshal: %v", err)
+		t.Fatalf("Marshal error: %v", err)
 	}
-	if string(b) != msg {
-		t.Fatalf("Marshal: have %#q want %#q", b, msg)
+	if string(got) != want {
+		t.Fatalf("Marshal:\n\tgot:  %s\n\twant: %s", got, want)
 	}
 }
 
@@ -268,174 +334,156 @@ func TestNullRawMessage(t *testing.T) {
 		IdPtr *RawMessage
 		Y     float32
 	}
-	const msg = `{"X":0.1,"Id":null,"IdPtr":null,"Y":0.2}`
-	err := Unmarshal([]byte(msg), &data)
+	const want = `{"X":0.1,"Id":null,"IdPtr":null,"Y":0.2}`
+	err := Unmarshal([]byte(want), &data)
 	if err != nil {
-		t.Fatalf("Unmarshal: %v", err)
+		t.Fatalf("Unmarshal error: %v", err)
 	}
 	if want, got := "null", string(data.Id); want != got {
-		t.Fatalf("Raw mismatch: have %q, want %q", got, want)
+		t.Fatalf("Unmarshal:\n\tgot:  %s\n\twant: %s", got, want)
 	}
 	if data.IdPtr != nil {
-		t.Fatalf("Raw pointer mismatch: have non-nil, want nil")
+		t.Fatalf("pointer mismatch: got non-nil, want nil")
 	}
-	b, err := Marshal(&data)
+	got, err := Marshal(&data)
 	if err != nil {
-		t.Fatalf("Marshal: %v", err)
+		t.Fatalf("Marshal error: %v", err)
 	}
-	if string(b) != msg {
-		t.Fatalf("Marshal: have %#q want %#q", b, msg)
+	if string(got) != want {
+		t.Fatalf("Marshal:\n\tgot:  %s\n\twant: %s", got, want)
 	}
-}
-
-var blockingTests = []string{
-	`{"x": 1}`,
-	`[1, 2, 3]`,
 }
 
 func TestBlocking(t *testing.T) {
-	for _, enc := range blockingTests {
-		r, w := net.Pipe()
-		go w.Write([]byte(enc))
-		var val any
-
-		// If Decode reads beyond what w.Write writes above,
-		// it will block, and the test will deadlock.
-		if err := NewDecoder(r).Decode(&val); err != nil {
-			t.Errorf("decoding %s: %v", enc, err)
-		}
-		r.Close()
-		w.Close()
+	tests := []struct {
+		CaseName
+		in string
+	}{
+		{Name(""), `{"x": 1}`},
+		{Name(""), `[1, 2, 3]`},
 	}
-}
+	for _, tt := range tests {
+		t.Run(tt.Name, func(t *testing.T) {
+			r, w := net.Pipe()
+			go w.Write([]byte(tt.in))
+			var val any
 
-func BenchmarkEncoderEncode(b *testing.B) {
-	b.ReportAllocs()
-	type T struct {
-		X, Y string
-	}
-	v := &T{"foo", "bar"}
-	b.RunParallel(func(pb *testing.PB) {
-		for pb.Next() {
-			if err := NewEncoder(io.Discard).Encode(v); err != nil {
-				b.Fatal(err)
+			// If Decode reads beyond what w.Write writes above,
+			// it will block, and the test will deadlock.
+			if err := NewDecoder(r).Decode(&val); err != nil {
+				t.Errorf("%s: NewDecoder(%s).Decode error: %v", tt.Where, tt.in, err)
 			}
-		}
-	})
-}
-
-type tokenStreamCase struct {
-	json      string
-	expTokens []any
+			r.Close()
+			w.Close()
+		})
+	}
 }
 
 type decodeThis struct {
 	v any
 }
 
-var tokenStreamCases = []tokenStreamCase{
-	// streaming token cases
-	{json: `10`, expTokens: []any{float64(10)}},
-	{json: ` [10] `, expTokens: []any{
-		Delim('['), float64(10), Delim(']')}},
-	{json: ` [false,10,"b"] `, expTokens: []any{
-		Delim('['), false, float64(10), "b", Delim(']')}},
-	{json: `{ "a": 1 }`, expTokens: []any{
-		Delim('{'), "a", float64(1), Delim('}')}},
-	{json: `{"a": 1, "b":"3"}`, expTokens: []any{
-		Delim('{'), "a", float64(1), "b", "3", Delim('}')}},
-	{json: ` [{"a": 1},{"a": 2}] `, expTokens: []any{
-		Delim('['),
-		Delim('{'), "a", float64(1), Delim('}'),
-		Delim('{'), "a", float64(2), Delim('}'),
-		Delim(']')}},
-	{json: `{"obj": {"a": 1}}`, expTokens: []any{
-		Delim('{'), "obj", Delim('{'), "a", float64(1), Delim('}'),
-		Delim('}')}},
-	{json: `{"obj": [{"a": 1}]}`, expTokens: []any{
-		Delim('{'), "obj", Delim('['),
-		Delim('{'), "a", float64(1), Delim('}'),
-		Delim(']'), Delim('}')}},
-
-	// streaming tokens with intermittent Decode()
-	{json: `{ "a": 1 }`, expTokens: []any{
-		Delim('{'), "a",
-		decodeThis{float64(1)},
-		Delim('}')}},
-	{json: ` [ { "a" : 1 } ] `, expTokens: []any{
-		Delim('['),
-		decodeThis{map[string]any{"a": float64(1)}},
-		Delim(']')}},
-	{json: ` [{"a": 1},{"a": 2}] `, expTokens: []any{
-		Delim('['),
-		decodeThis{map[string]any{"a": float64(1)}},
-		decodeThis{map[string]any{"a": float64(2)}},
-		Delim(']')}},
-	{json: `{ "obj" : [ { "a" : 1 } ] }`, expTokens: []any{
-		Delim('{'), "obj", Delim('['),
-		decodeThis{map[string]any{"a": float64(1)}},
-		Delim(']'), Delim('}')}},
-
-	{json: `{"obj": {"a": 1}}`, expTokens: []any{
-		Delim('{'), "obj",
-		decodeThis{map[string]any{"a": float64(1)}},
-		Delim('}')}},
-	{json: `{"obj": [{"a": 1}]}`, expTokens: []any{
-		Delim('{'), "obj",
-		decodeThis{[]any{
-			map[string]any{"a": float64(1)},
-		}},
-		Delim('}')}},
-	{json: ` [{"a": 1} {"a": 2}] `, expTokens: []any{
-		Delim('['),
-		decodeThis{map[string]any{"a": float64(1)}},
-		decodeThis{&SyntaxError{"expected comma after array element", 11}},
-	}},
-	{json: `{ "` + strings.Repeat("a", 513) + `" 1 }`, expTokens: []any{
-		Delim('{'), strings.Repeat("a", 513),
-		decodeThis{&SyntaxError{"expected colon after object key", 518}},
-	}},
-	{json: `{ "\a" }`, expTokens: []any{
-		Delim('{'),
-		&SyntaxError{"invalid character 'a' in string escape code", 3},
-	}},
-	{json: ` \a`, expTokens: []any{
-		&SyntaxError{"invalid character '\\\\' looking for beginning of value", 1},
-	}},
-}
-
 func TestDecodeInStream(t *testing.T) {
-	for ci, tcase := range tokenStreamCases {
+	tests := []struct {
+		CaseName
+		json      string
+		expTokens []any
+	}{
+		// streaming token cases
+		{CaseName: Name(""), json: `10`, expTokens: []any{float64(10)}},
+		{CaseName: Name(""), json: ` [10] `, expTokens: []any{
+			Delim('['), float64(10), Delim(']')}},
+		{CaseName: Name(""), json: ` [false,10,"b"] `, expTokens: []any{
+			Delim('['), false, float64(10), "b", Delim(']')}},
+		{CaseName: Name(""), json: `{ "a": 1 }`, expTokens: []any{
+			Delim('{'), "a", float64(1), Delim('}')}},
+		{CaseName: Name(""), json: `{"a": 1, "b":"3"}`, expTokens: []any{
+			Delim('{'), "a", float64(1), "b", "3", Delim('}')}},
+		{CaseName: Name(""), json: ` [{"a": 1},{"a": 2}] `, expTokens: []any{
+			Delim('['),
+			Delim('{'), "a", float64(1), Delim('}'),
+			Delim('{'), "a", float64(2), Delim('}'),
+			Delim(']')}},
+		{CaseName: Name(""), json: `{"obj": {"a": 1}}`, expTokens: []any{
+			Delim('{'), "obj", Delim('{'), "a", float64(1), Delim('}'),
+			Delim('}')}},
+		{CaseName: Name(""), json: `{"obj": [{"a": 1}]}`, expTokens: []any{
+			Delim('{'), "obj", Delim('['),
+			Delim('{'), "a", float64(1), Delim('}'),
+			Delim(']'), Delim('}')}},
 
-		dec := NewDecoder(strings.NewReader(tcase.json))
-		for i, etk := range tcase.expTokens {
+		// streaming tokens with intermittent Decode()
+		{CaseName: Name(""), json: `{ "a": 1 }`, expTokens: []any{
+			Delim('{'), "a",
+			decodeThis{float64(1)},
+			Delim('}')}},
+		{CaseName: Name(""), json: ` [ { "a" : 1 } ] `, expTokens: []any{
+			Delim('['),
+			decodeThis{map[string]any{"a": float64(1)}},
+			Delim(']')}},
+		{CaseName: Name(""), json: ` [{"a": 1},{"a": 2}] `, expTokens: []any{
+			Delim('['),
+			decodeThis{map[string]any{"a": float64(1)}},
+			decodeThis{map[string]any{"a": float64(2)}},
+			Delim(']')}},
+		{CaseName: Name(""), json: `{ "obj" : [ { "a" : 1 } ] }`, expTokens: []any{
+			Delim('{'), "obj", Delim('['),
+			decodeThis{map[string]any{"a": float64(1)}},
+			Delim(']'), Delim('}')}},
 
-			var tk any
-			var err error
+		{CaseName: Name(""), json: `{"obj": {"a": 1}}`, expTokens: []any{
+			Delim('{'), "obj",
+			decodeThis{map[string]any{"a": float64(1)}},
+			Delim('}')}},
+		{CaseName: Name(""), json: `{"obj": [{"a": 1}]}`, expTokens: []any{
+			Delim('{'), "obj",
+			decodeThis{[]any{
+				map[string]any{"a": float64(1)},
+			}},
+			Delim('}')}},
+		{CaseName: Name(""), json: ` [{"a": 1} {"a": 2}] `, expTokens: []any{
+			Delim('['),
+			decodeThis{map[string]any{"a": float64(1)}},
+			decodeThis{&SyntaxError{"expected comma after array element", 11}},
+		}},
+		{CaseName: Name(""), json: `{ "` + strings.Repeat("a", 513) + `" 1 }`, expTokens: []any{
+			Delim('{'), strings.Repeat("a", 513),
+			decodeThis{&SyntaxError{"expected colon after object key", 518}},
+		}},
+		{CaseName: Name(""), json: `{ "\a" }`, expTokens: []any{
+			Delim('{'),
+			&SyntaxError{"invalid character 'a' in string escape code", 3},
+		}},
+		{CaseName: Name(""), json: ` \a`, expTokens: []any{
+			&SyntaxError{"invalid character '\\\\' looking for beginning of value", 1},
+		}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.Name, func(t *testing.T) {
+			dec := NewDecoder(strings.NewReader(tt.json))
+			for i, want := range tt.expTokens {
+				var got any
+				var err error
 
-			if dt, ok := etk.(decodeThis); ok {
-				etk = dt.v
-				err = dec.Decode(&tk)
-			} else {
-				tk, err = dec.Token()
-			}
-			if experr, ok := etk.(error); ok {
-				if err == nil || !reflect.DeepEqual(err, experr) {
-					t.Errorf("case %v: Expected error %#v in %q, but was %#v", ci, experr, tcase.json, err)
+				if dt, ok := want.(decodeThis); ok {
+					want = dt.v
+					err = dec.Decode(&got)
+				} else {
+					got, err = dec.Token()
 				}
-				break
-			} else if err == io.EOF {
-				t.Errorf("case %v: Unexpected EOF in %q", ci, tcase.json)
-				break
-			} else if err != nil {
-				t.Errorf("case %v: Unexpected error '%#v' in %q", ci, err, tcase.json)
-				break
+				if errWant, ok := want.(error); ok {
+					if err == nil || !reflect.DeepEqual(err, errWant) {
+						t.Fatalf("%s:\n\tinput: %s\n\tgot error:  %v\n\twant error: %v", tt.Where, tt.json, err, errWant)
+					}
+					break
+				} else if err != nil {
+					t.Fatalf("%s:\n\tinput: %s\n\tgot error:  %v\n\twant error: nil", tt.Where, tt.json, err)
+				}
+				if !reflect.DeepEqual(got, want) {
+					t.Fatalf("%s: token %d:\n\tinput: %s\n\tgot:  %T(%v)\n\twant: %T(%v)", tt.Where, i, tt.json, got, got, want, want)
+				}
 			}
-			if !reflect.DeepEqual(tk, etk) {
-				t.Errorf(`case %v: %q @ %v expected %T(%v) was %T(%v)`, ci, tcase.json, i, etk, etk, tk, tk)
-				break
-			}
-		}
+		})
 	}
 }
 
@@ -449,7 +497,7 @@ func TestHTTPDecoding(t *testing.T) {
 	defer ts.Close()
 	res, err := http.Get(ts.URL)
 	if err != nil {
-		log.Fatalf("GET failed: %v", err)
+		log.Fatalf("http.Get error: %v", err)
 	}
 	defer res.Body.Close()
 
@@ -460,15 +508,15 @@ func TestHTTPDecoding(t *testing.T) {
 	d := NewDecoder(res.Body)
 	err = d.Decode(&foo)
 	if err != nil {
-		t.Fatalf("Decode: %v", err)
+		t.Fatalf("Decode error: %v", err)
 	}
 	if foo.Foo != "bar" {
-		t.Errorf("decoded %q; want \"bar\"", foo.Foo)
+		t.Errorf(`Decode: got %q, want "bar"`, foo.Foo)
 	}
 
 	// make sure we get the EOF the second time
 	err = d.Decode(&foo)
 	if err != io.EOF {
-		t.Errorf("err = %v; want io.EOF", err)
+		t.Errorf("Decode error:\n\tgot:  %v\n\twant: io.EOF", err)
 	}
 }

--- a/internal/golang/encoding/json/tagkey_test.go
+++ b/internal/golang/encoding/json/tagkey_test.go
@@ -72,49 +72,50 @@ type unicodeTag struct {
 	W string `json:"Ελλάδα"`
 }
 
-var structTagObjectKeyTests = []struct {
-	raw   any
-	value string
-	key   string
-}{
-	{basicLatin2xTag{"2x"}, "2x", "$%-/"},
-	{basicLatin3xTag{"3x"}, "3x", "0123456789"},
-	{basicLatin4xTag{"4x"}, "4x", "ABCDEFGHIJKLMO"},
-	{basicLatin5xTag{"5x"}, "5x", "PQRSTUVWXYZ_"},
-	{basicLatin6xTag{"6x"}, "6x", "abcdefghijklmno"},
-	{basicLatin7xTag{"7x"}, "7x", "pqrstuvwxyz"},
-	{miscPlaneTag{"いろはにほへと"}, "いろはにほへと", "色は匂へど"},
-	{dashTag{"foo"}, "foo", "-"},
-	{emptyTag{"Pour Moi"}, "Pour Moi", "W"},
-	{misnamedTag{"Animal Kingdom"}, "Animal Kingdom", "X"},
-	{badFormatTag{"Orfevre"}, "Orfevre", "Y"},
-	{badCodeTag{"Reliable Man"}, "Reliable Man", "Z"},
-	{percentSlashTag{"brut"}, "brut", "text/html%"},
-	{punctuationTag{"Union Rags"}, "Union Rags", "!#$%&()*+-./:;<=>?@[]^_{|}~ "},
-	{spaceTag{"Perreddu"}, "Perreddu", "With space"},
-	{unicodeTag{"Loukanikos"}, "Loukanikos", "Ελλάδα"},
-}
-
 func TestStructTagObjectKey(t *testing.T) {
-	for _, tt := range structTagObjectKeyTests {
-		b, err := Marshal(tt.raw)
-		if err != nil {
-			t.Fatalf("Marshal(%#q) failed: %v", tt.raw, err)
-		}
-		var f any
-		err = Unmarshal(b, &f)
-		if err != nil {
-			t.Fatalf("Unmarshal(%#q) failed: %v", b, err)
-		}
-		for i, v := range f.(map[string]any) {
-			switch i {
-			case tt.key:
-				if s, ok := v.(string); !ok || s != tt.value {
-					t.Fatalf("Unexpected value: %#q, want %v", s, tt.value)
-				}
-			default:
-				t.Fatalf("Unexpected key: %#q, from %#q", i, b)
+	tests := []struct {
+		CaseName
+		raw   any
+		value string
+		key   string
+	}{
+		{Name(""), basicLatin2xTag{"2x"}, "2x", "$%-/"},
+		{Name(""), basicLatin3xTag{"3x"}, "3x", "0123456789"},
+		{Name(""), basicLatin4xTag{"4x"}, "4x", "ABCDEFGHIJKLMO"},
+		{Name(""), basicLatin5xTag{"5x"}, "5x", "PQRSTUVWXYZ_"},
+		{Name(""), basicLatin6xTag{"6x"}, "6x", "abcdefghijklmno"},
+		{Name(""), basicLatin7xTag{"7x"}, "7x", "pqrstuvwxyz"},
+		{Name(""), miscPlaneTag{"いろはにほへと"}, "いろはにほへと", "色は匂へど"},
+		{Name(""), dashTag{"foo"}, "foo", "-"},
+		{Name(""), emptyTag{"Pour Moi"}, "Pour Moi", "W"},
+		{Name(""), misnamedTag{"Animal Kingdom"}, "Animal Kingdom", "X"},
+		{Name(""), badFormatTag{"Orfevre"}, "Orfevre", "Y"},
+		{Name(""), badCodeTag{"Reliable Man"}, "Reliable Man", "Z"},
+		{Name(""), percentSlashTag{"brut"}, "brut", "text/html%"},
+		{Name(""), punctuationTag{"Union Rags"}, "Union Rags", "!#$%&()*+-./:;<=>?@[]^_{|}~ "},
+		{Name(""), spaceTag{"Perreddu"}, "Perreddu", "With space"},
+		{Name(""), unicodeTag{"Loukanikos"}, "Loukanikos", "Ελλάδα"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.Name, func(t *testing.T) {
+			b, err := Marshal(tt.raw)
+			if err != nil {
+				t.Fatalf("%s: Marshal error: %v", tt.Where, err)
 			}
-		}
+			var f any
+			err = Unmarshal(b, &f)
+			if err != nil {
+				t.Fatalf("%s: Unmarshal error: %v", tt.Where, err)
+			}
+			for k, v := range f.(map[string]any) {
+				if k == tt.key {
+					if s, ok := v.(string); !ok || s != tt.value {
+						t.Fatalf("%s: Unmarshal(%#q) value:\n\tgot:  %q\n\twant: %q", tt.Where, b, s, tt.value)
+					}
+				} else {
+					t.Fatalf("%s: Unmarshal(%#q): unexpected key: %q", tt.Where, b, k)
+				}
+			}
+		})
 	}
 }

--- a/internal/golang/encoding/json/tags_test.go
+++ b/internal/golang/encoding/json/tags_test.go
@@ -22,7 +22,7 @@ func TestTagParsing(t *testing.T) {
 		{"bar", false},
 	} {
 		if opts.Contains(tt.opt) != tt.want {
-			t.Errorf("Contains(%q) = %v", tt.opt, !tt.want)
+			t.Errorf("Contains(%q) = %v, want %v", tt.opt, !tt.want, tt.want)
 		}
 	}
 }


### PR DESCRIPTION
First commit is a straight copy of the json/encoding files from stdlib on the go 1.23 release branch

Second commit is a reapply of carry patches to those files

Third commit is a tweak to make the external dependency check work with go 1.23 `go mod graph` behavior